### PR TITLE
refactor(views): replace static router import with useRouter() composable

### DIFF
--- a/src/views/GameResultView.vue
+++ b/src/views/GameResultView.vue
@@ -1,13 +1,15 @@
 <script lang="ts" setup>
+import { useRouter } from 'vue-router';
+
 import GameResultScreen from '@/screens/GameResultScreen.vue';
 
-import { router } from '@/router';
 import { routeName } from '@/router/routerName';
 
 import { useGameLogic } from '@/composables/useGameLogic';
 
 /* ========================================================================== */
 
+const router = useRouter();
 const gameLogic = useGameLogic();
 
 /* -------------------------------------------------------------------------- */

--- a/src/views/RoundView.vue
+++ b/src/views/RoundView.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 import { storeToRefs } from 'pinia';
+import { useRouter } from 'vue-router';
 
 import { useGlobalI18n } from '@/i18n';
 
-import { router } from '@/router';
 import { routeName } from '@/router/routerName';
 
 import CollectPointsScreen from '@/screens/CollectPointsScreen.vue';
@@ -19,6 +19,8 @@ import { useRoundManager } from '@/composables/useRoundManager';
 import { useRoundsStore } from '@/stores/rounds';
 
 /* ========================================================================== */
+
+const router = useRouter();
 
 const { t } = useGlobalI18n();
 const roundsStore = useRoundsStore();


### PR DESCRIPTION
Importing the router singleton directly is the pattern for non-component contexts. Inside <script setup>, useRouter() is the idiomatic Vue Router 4 approach and aligns with GameLimitView and GamePlayersView.