### PR TITLE
refactor(rounds): move round ordinal computation into the rounds store

### DIFF
--- a/src/composables/useRoundsLogic.ts
+++ b/src/composables/useRoundsLogic.ts
@@ -23,7 +23,7 @@ export function useRoundsLogic() {
 
 	const { activePlayers } = storeToRefs(playersStore);
 	const { startingStoneCount } = useRules();
-	const { currentPlayerId, currentRound, hasCurrentRound } = storeToRefs(roundsStore);
+	const { currentPlayerId, currentRound, currentRoundOrdinal, hasCurrentRound } = storeToRefs(roundsStore);
 	const { t } = useGlobalI18n();
 
 	/* ---------------------------------------------------------------------- */
@@ -145,6 +145,7 @@ export function useRoundsLogic() {
 	/* ---------------------------------------------------------------------- */
 
 	return {
+		currentRoundOrdinal,
 		finishCurrentRound,
 		saveTurn,
 		startNewRound

--- a/src/screens/StartingPlayerScreen.vue
+++ b/src/screens/StartingPlayerScreen.vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { usePlayersStore } from '@/stores/players';
 
-import AppScreen from '@/screens/AppScreen.vue';
 import MessageBox from '@/components/MessageBox.vue';
 import ToggleButton from '@/components/ToggleButton.vue';
 import ToggleButtonGroup from '@/components/ToggleButtonGroup.vue';
 
 import { useRules } from '@/composables/useRules';
-import { useRoundsStore } from '@/stores/rounds';
+import { useRoundsLogic } from '@/composables/useRoundsLogic';
+
+import AppScreen from '@/screens/AppScreen.vue';
 
 /* ========================================================================== */
 
@@ -21,15 +22,13 @@ const emit = defineEmits<{
 
 /* -------------------------------------------------------------------------- */
 
+const { currentRoundOrdinal } = useRoundsLogic();
+
 const playerStore = usePlayersStore();
-const roundsStore = useRoundsStore();
 
 const { activePlayers } = storeToRefs(playerStore);
-const { rounds } = storeToRefs(roundsStore);
 
 const { startingStoneCount } = useRules();
-
-const roundOrdinal = computed<number>(() => rounds.value.length);
 
 const selectedId = ref<Id | undefined>(undefined);
 const showValidationMessage = ref<boolean>(false);
@@ -56,7 +55,7 @@ function onNavigateForward(): void {
 </script>
 
 <template>
-	<AppScreen :title="$t('playerSelect.title', [roundOrdinal])">
+	<AppScreen :title="$t('playerSelect.title', [currentRoundOrdinal ?? 0])">
 		<MessageBox>
 			<div v-html="$t('playerSelect.infoMessage', [startingStoneCount])" />
 		</MessageBox>

--- a/src/stores/rounds.ts
+++ b/src/stores/rounds.ts
@@ -37,6 +37,10 @@ export const useRoundsStore = defineStore('round', () => {
 		return rounds.value.find(round => round.isCurrentRound);
 	});
 
+	const currentRoundOrdinal = computed<number | undefined>(() =>
+		(currentRound.value === undefined) ? undefined : getCurrentRoundIndex() + 1
+	);
+
 	/**
 	 * The ID of the current player in the current round, if it exists.
 	 */
@@ -314,6 +318,7 @@ export const useRoundsStore = defineStore('round', () => {
 		currentRoundScore,
 		currentPlayerId,
 		currentPlayerStats,
+		currentRoundOrdinal,
 		getCurrentRoundTileCountForPlayer,
 		hasCurrentRound,
 		playerScores,


### PR DESCRIPTION
StartingPlayerScreen was pulling the full rounds array from the store and computing the ordinal locally with rounds.value.length, which was also incorrect — it returned the total round count rather than the position of the current round.

Add a currentRoundOrdinal computed getter to useRoundsStore that delegates to the existing getCurrentRoundIndex helper, and expose it through useRoundsLogic. The screen now consumes the getter directly without touching raw store state.