### PR TITLE
fix(TurnScreen): reject array values from ToggleButtonGroup bonus handler

### DIFF
--- a/src/screens/TurnScreen.vue
+++ b/src/screens/TurnScreen.vue
@@ -90,7 +90,9 @@ function createScoredTurnInput(): ScoredTurnInput {
 /* -------------------------------------------------------------------------- */
 
 function onToggleBonusScoring(value: string | string[] | undefined) {
-	selectedBonusShape.value = value as BonusShape;
+	if (Array.isArray(value)) return;
+
+	selectedBonusShape.value = value as BonusShape | undefined;
 }
 
 function onNavigateForward() {


### PR DESCRIPTION
ToggleButtonGroup can emit string[] instead of string. The previous direct cast to BonusShape silently accepted arrays, causing all bonus shape comparisons (=== 'bridge', etc.) to fail and produce a turn with no bonus scored.

Array.isArray is used instead of a typeof guard so that undefined can still flow through, allowing deselection to clear the selected shape.