### PR TITLE
refactor(MainMenu): drive bottom sheet open state via local ref

### DIFF
--- a/src/components/BottomSheet.vue
+++ b/src/components/BottomSheet.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onUnmounted, watch } from 'vue';
+import { onUnmounted, toRef, watch } from 'vue';
 
 import { useBottomSheet } from '@/composables/useBottomSheet';
 
@@ -20,13 +20,14 @@ const props = defineProps<{
 /* -------------------------------------------------------------------------- */
 
 const { isBottomSheetOpen } = useBottomSheet();
+const isOpen = toRef(props, 'open');
 
 /* -------------------------------------------------------------------------- */
 
-watch(() => props.open, isOpen => {
-	isBottomSheetOpen.value = isOpen;
+watch(isOpen, value => {
+	isBottomSheetOpen.value = value;
 
-	if (isOpen) {
+	if (value) {
 		addEventListenersToDocument();
 	} else {
 		removeEventListenersFromDocument();

--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -10,7 +10,6 @@ import Leaderboard from '@/components/Leaderboard.vue';
 import SettingsPanel from '@/components/SettingsPanel.vue';
 
 import { useBuildInfo } from '@/composables/useBuildInfo';
-import { useBottomSheet } from '@/composables/useBottomSheet';
 
 /* ========================================================================== */
 
@@ -20,7 +19,6 @@ const emit = defineEmits<{ resetConfirmed: [] }>();
 
 const { hasActiveGame } = storeToRefs(useGameStore());
 const { appVersion, formattedBuildTimestamp } = useBuildInfo();
-const { isBottomSheetOpen } = useBottomSheet();
 
 /* -------------------------------------------------------------------------- */
 
@@ -32,7 +30,7 @@ function onResetConfirmed(): void {
 	// Make sure the bottom sheet is closed before emitting the reset event.
 	// Failure to do so will result in a UI glitch where the body is still
 	// shrunk without the bottom sheet being visible.
-	isBottomSheetOpen.value = false;
+	isOpen.value = false;
 
 	nextTick(() => emit('resetConfirmed'));
 }


### PR DESCRIPTION
MainMenu was coupling to useBottomSheet to imperatively close the sheet on game reset. Managing open state with a local ref and passing it as a prop keeps the component self-contained and avoids reaching into the composable's internal state. BottomSheet's watcher is updated to use toRef for idiomatic prop observation.