### PR TITLE
test(vitest): migrate to jsdom environment and add first unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@types/jsdom": "^28.0.1",
     "@types/node": "^25.6.0",
     "@vitejs/plugin-vue": "^6.0.6",
-    "@vitest/browser-playwright": "^4.1.5",
     "@vitest/eslint-plugin": "^1.6.16",
     "@vue/eslint-config-typescript": "^14.7.0",
     "@vue/test-utils": "^2.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
         version: 6.0.6(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))
-      '@vitest/browser-playwright':
-        specifier: ^4.1.5
-        version: 4.1.5(playwright@1.59.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vitest@4.1.5)
       '@vitest/eslint-plugin':
         specifier: ^1.6.16
         version: 1.6.16(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.5)
@@ -3804,7 +3801,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@blazediff/core@1.9.1': {}
+  '@blazediff/core@1.9.1':
+    optional: true
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -4733,6 +4731,7 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
   '@vitest/browser@4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(yaml@2.8.3))(vitest@4.1.5)':
     dependencies:
@@ -4750,6 +4749,7 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
   '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.5)':
     dependencies:
@@ -6301,7 +6301,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  pngjs@7.0.0: {}
+  pngjs@7.0.0:
+    optional: true
 
   postcss-selector-parser@7.1.1:
     dependencies:

--- a/src/utilities/string.test.ts
+++ b/src/utilities/string.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { isNilOrEmptyString } from './string';
+
+/* ========================================================================== */
+
+describe('isNilOrEmptyString', () => {
+	describe('returns true for nil values', () => {
+		it('returns true for null', () => {
+			expect(isNilOrEmptyString(null)).toBe(true);
+		});
+
+		it('returns true for undefined', () => {
+			expect(isNilOrEmptyString(undefined)).toBe(true);
+		});
+	});
+
+	describe('returns true for empty or whitespace-only strings', () => {
+		it('returns true for an empty string', () => {
+			expect(isNilOrEmptyString('')).toBe(true);
+		});
+
+		it('returns true for a string with only spaces', () => {
+			expect(isNilOrEmptyString('   ')).toBe(true);
+		});
+
+		it('returns true for a string with only tabs', () => {
+			expect(isNilOrEmptyString('\t\t')).toBe(true);
+		});
+
+		it('returns true for a string with mixed whitespace', () => {
+			expect(isNilOrEmptyString(' \t \n ')).toBe(true);
+		});
+	});
+
+	describe('returns false for non-empty values', () => {
+		it('returns false for a non-empty string', () => {
+			expect(isNilOrEmptyString('hello')).toBe(false);
+		});
+
+		it('returns false for a string with leading/trailing whitespace around content', () => {
+			expect(isNilOrEmptyString('  hello  ')).toBe(false);
+		});
+
+		it('returns false for a number', () => {
+			expect(isNilOrEmptyString(42)).toBe(false);
+		});
+
+		it('returns false for zero', () => {
+			expect(isNilOrEmptyString(0)).toBe(false);
+		});
+
+		it('returns false for false', () => {
+			expect(isNilOrEmptyString(false)).toBe(false);
+		});
+
+		it('returns false for an object', () => {
+			expect(isNilOrEmptyString({})).toBe(false);
+		});
+
+		it('returns false for an array', () => {
+			expect(isNilOrEmptyString([])).toBe(false);
+		});
+	});
+});

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -6,6 +6,6 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
 
     "lib": [],
-    "types": ["node", "jsdom"]
+    "types": ["node", "jsdom", "vitest/globals"]
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,8 +32,8 @@ export default defineConfig({
 
 	plugins: [
 		vue(),
-		vueDevTools(),
-		mkcert({
+		!process.env.VITEST && vueDevTools(),
+		!process.env.VITEST && mkcert({
 			savePath: './ssl'
 		})
 	],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { mergeConfig } from 'vite';
 import { defineConfig, configDefaults } from 'vitest/config';
-import { playwright } from '@vitest/browser-playwright';
 
 import viteConfig from './vite.config';
 
@@ -9,14 +8,9 @@ import viteConfig from './vite.config';
 
 const vitestConfig = {
 	test: {
-		browser: {
-			enabled: true,
-			instances: [
-				{ browser: 'chromium' }
-			],
-			provider: playwright()
-		},
+		environment: 'jsdom',
 		exclude: [...configDefaults.exclude, 'e2e/**'],
+		globals: true,
 		root: fileURLToPath(new URL('./', import.meta.url))
 	}
 };


### PR DESCRIPTION
Browser mode added unnecessary complexity for testing pure utility
functions that have no DOM or component dependencies. Switching to
jsdom removes that overhead and lets tests run faster without a
headless browser.

Dev-only Vite plugins (e.g. the Vue DevTools plugin) were also being
loaded during Vitest runs, causing compatibility noise unrelated to
the tests themselves. These are now excluded when running under Vitest.

With the environment stable, the first unit tests are added for the
`isNilOrEmptyString` string utility to verify edge cases and establish
the pattern for future coverage.