### PR TITLE
refactor(useGameLogic): rename clearGameData to resetGameProgress

### DIFF
--- a/src/composables/useGameLogic.ts
+++ b/src/composables/useGameLogic.ts
@@ -28,9 +28,11 @@ export function useGameLogic() {
 	}
 
 	/**
-	 * Removes all data pertaining to the current game from the stores.
+	 * Resets the game progress by clearing the turns, rounds, and game data.
+	 * The players store is intentionally preserved so users can start a new
+	 * game with the same group without re-entering names.
 	 */
-	function clearGameData(): void {
+	function resetGameProgress(): void {
 		useTurnsStore().$reset();
 		useRoundsStore().$reset();
 		gameStore.$reset();
@@ -56,7 +58,7 @@ export function useGameLogic() {
 
 	return {
 		isValidLimit,
-		clearGameData,
+		resetGameProgress,
 		startNewGame
 	};
 }

--- a/src/screens/AppScreen.vue
+++ b/src/screens/AppScreen.vue
@@ -18,11 +18,11 @@ defineProps<{
 
 /* ========================================================================== */
 
-const { clearGameData } = useGameLogic();
+const { resetGameProgress } = useGameLogic();
 const router = useRouter();
 
 function onResetConfirmed(): void {
-	clearGameData();
+	resetGameProgress();
 	// AppScreen is the shared layout shell for every route, so no individual
 	// view can own the post-reset navigation. Placing it here is the narrowest
 	// scope that still covers all screens without duplicating it in each view.

--- a/src/views/GameResultView.vue
+++ b/src/views/GameResultView.vue
@@ -15,7 +15,7 @@ const gameLogic = useGameLogic();
 /* -------------------------------------------------------------------------- */
 
 function onNewGame() {
-	gameLogic.clearGameData();
+	gameLogic.resetGameProgress();
 	router.replace({ name: routeName.home });
 }
 </script>


### PR DESCRIPTION
The name clearGameData implied a full reset but silently skipped the players store, which could mislead future contributors into treating the omission as a bug. The new name better reflects the actual scope of the function.

A JSDoc comment now explicitly states that the players store is intentionally preserved so users can replay with the same group without re-entering names. Callers in AppScreen and GameResultView are updated to use the new name.