### PR TITLE
refactor(useRules): remove Pinia dependency by replacing reactive computed with pure function

### DIFF
--- a/src/composables/useRoundsLogic.ts
+++ b/src/composables/useRoundsLogic.ts
@@ -22,7 +22,7 @@ export function useRoundsLogic() {
 	/* ---------------------------------------------------------------------- */
 
 	const { activePlayers } = storeToRefs(playersStore);
-	const { startingStoneCount } = useRules();
+	const { determineStonesPerPlayer } = useRules();
 	const { currentPlayerId, currentRound, currentRoundOrdinal, hasCurrentRound } = storeToRefs(roundsStore);
 	const { t } = useGlobalI18n();
 
@@ -35,12 +35,13 @@ export function useRoundsLogic() {
 	 */
 	function initializePlayerStats(): PlayerStats[] {
 		const stats: PlayerStats[] = [];
+		const stoneCount = determineStonesPerPlayer(activePlayers.value.length);
 
 		for (const player of activePlayers.value) {
 			stats.push({
 				id: player.id,
 				score: 0,
-				tiles: startingStoneCount.value
+				tiles: stoneCount
 			});
 		};
 

--- a/src/composables/useRules.test.ts
+++ b/src/composables/useRules.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it } from 'vitest';
+
+import { generateId } from '@/utilities/id';
+
+import { useRules } from './useRules';
+
+/* ========================================================================== */
+describe('useRules', () => {
+	describe('calculateStartingStoneBonus', () => {
+		it('should return 40 when the tile value is 0 (opening zero bonus)', () => {
+			const { calculateStartingStoneBonus } = useRules();
+			expect(calculateStartingStoneBonus(0)).toBe(40);
+		});
+
+		it('should return 10 for possible triple stone values', () => {
+			const { calculateStartingStoneBonus } = useRules();
+			expect(calculateStartingStoneBonus(3)).toBe(10);
+			expect(calculateStartingStoneBonus(9)).toBe(10);
+			expect(calculateStartingStoneBonus(15)).toBe(10);
+		});
+
+		it('should return 0 for tiles which cannot be a triple stone', () => {
+			const { calculateStartingStoneBonus } = useRules();
+			expect(calculateStartingStoneBonus(7)).toBe(0);
+			expect(calculateStartingStoneBonus(11)).toBe(0);
+			expect(calculateStartingStoneBonus(2)).toBe(0);
+		});
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	describe('calculateTurnScore', () => {
+		describe('skipped turns (tilesPlayed: 0)', () => {
+			it('should return -10 when no tiles are drawn', () => {
+				const { calculateTurnScore } = useRules();
+
+				expect(
+					calculateTurnScore({ tilesPlayed: 0, tilesDrawn: 0, tileValue: undefined })
+				).toBe(-10);
+			});
+
+			it('should subtract 5 per tile drawn on top of the skip penalty', () => {
+				const { calculateTurnScore } = useRules();
+
+				expect(
+					calculateTurnScore({ tilesPlayed: 0, tilesDrawn: 1, tileValue: undefined })
+				).toBe(-15);
+				expect(
+					calculateTurnScore({ tilesPlayed: 0, tilesDrawn: 2, tileValue: undefined })
+				).toBe(-20);
+				expect(
+					calculateTurnScore({ tilesPlayed: 0, tilesDrawn: 3, tileValue: undefined })
+				).toBe(-25);
+			});
+		});
+
+		describe('played turns (tilesPlayed: 1)', () => {
+			it('should return the tile value when no draws and no bonuses', () => {
+				const { calculateTurnScore } = useRules();
+
+				expect(calculateTurnScore({
+					tilesPlayed: 1, tilesDrawn: 0, tileValue: 15,
+					triple: false, bonusBridge: false, bonusDouble: false, bonusHexagon: false
+				})).toBe(15);
+			});
+
+			it('should subtract 5 per tile drawn', () => {
+				const { calculateTurnScore } = useRules();
+
+				expect(calculateTurnScore({
+					tilesPlayed: 1, tilesDrawn: 1, tileValue: 15,
+					triple: false, bonusBridge: false, bonusDouble: false, bonusHexagon: false
+				})).toBe(10);
+
+				expect(calculateTurnScore({
+					tilesPlayed: 1, tilesDrawn: 3, tileValue: 15,
+					triple: false, bonusBridge: false, bonusDouble: false, bonusHexagon: false
+				})).toBe(0);
+			});
+
+			describe('opening triple bonuses', () => {
+				it('should add 40 for a 0-value opening tile', () => {
+					const { calculateTurnScore } = useRules();
+
+					expect(calculateTurnScore({
+						tilesPlayed: 1, tilesDrawn: 0, tileValue: 0,
+						triple: true, bonusBridge: false, bonusDouble: false, bonusHexagon: false
+					})).toBe(40);
+				});
+
+				it('should add 10 for a non-zero opening tile', () => {
+					const { calculateTurnScore } = useRules();
+
+					expect(calculateTurnScore({
+						tilesPlayed: 1, tilesDrawn: 0, tileValue: 9,
+						triple: true, bonusBridge: false, bonusDouble: false, bonusHexagon: false
+					})).toBe(19);
+				});
+
+				it('should not apply opening bonus when triple is false', () => {
+					const { calculateTurnScore } = useRules();
+
+					expect(calculateTurnScore({
+						tilesPlayed: 1, tilesDrawn: 0, tileValue: 9,
+						triple: false, bonusBridge: false, bonusDouble: false, bonusHexagon: false
+					})).toBe(9);
+				});
+			});
+
+			describe('special tile bonuses', () => {
+				it('should add 40 for a bridge bonus', () => {
+					const { calculateTurnScore } = useRules();
+
+					expect(calculateTurnScore({
+						tilesPlayed: 1, tilesDrawn: 0, tileValue: 15,
+						triple: false, bonusBridge: true, bonusDouble: false, bonusHexagon: false
+					})).toBe(55);
+				});
+
+				it('should add 40 for a double-sided bonus', () => {
+					const { calculateTurnScore } = useRules();
+
+					expect(calculateTurnScore({
+						tilesPlayed: 1, tilesDrawn: 0, tileValue: 15,
+						triple: false, bonusBridge: false, bonusDouble: true, bonusHexagon: false
+					})).toBe(55);
+				});
+
+				it('should add 50 for a hexagon bonus', () => {
+					const { calculateTurnScore } = useRules();
+
+					expect(calculateTurnScore({
+						tilesPlayed: 1, tilesDrawn: 0, tileValue: 15,
+						triple: false, bonusBridge: false, bonusDouble: false, bonusHexagon: true
+					})).toBe(65);
+				});
+
+				it('should stack all three special bonuses', () => {
+					const { calculateTurnScore } = useRules();
+
+					// 15 + 40 (bridge) + 40 (double) + 50 (hexagon) = 145
+					expect(calculateTurnScore({
+						tilesPlayed: 1, tilesDrawn: 0, tileValue: 15,
+						triple: false, bonusBridge: true, bonusDouble: true, bonusHexagon: true
+					})).toBe(145);
+				});
+
+				it('should combine draws and bonuses correctly', () => {
+					const { calculateTurnScore } = useRules();
+
+					// 15 - 5 (1 draw) + 40 (bridge) = 50
+					expect(calculateTurnScore({
+						tilesPlayed: 1, tilesDrawn: 1, tileValue: 15,
+						triple: false, bonusBridge: true, bonusDouble: false, bonusHexagon: false
+					})).toBe(50);
+				});
+			});
+		});
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	describe('canTileBeTripleStone', () => {
+		it('should return true for 0', () => {
+			const { canTileBeTripleStone } = useRules();
+			expect(canTileBeTripleStone(0)).toBe(true);
+		});
+
+		it('should return true when the tile value is a multiple of 3', () => {
+			const { canTileBeTripleStone } = useRules();
+			expect(canTileBeTripleStone(3)).toBe(true);
+			expect(canTileBeTripleStone(9)).toBe(true);
+			expect(canTileBeTripleStone(15)).toBe(true);
+		});
+
+		it('should return false when the tile value is not a multiple of 3', () => {
+			const { canTileBeTripleStone } = useRules();
+			expect(canTileBeTripleStone(7)).toBe(false);
+			expect(canTileBeTripleStone(11)).toBe(false);
+			expect(canTileBeTripleStone(2)).toBe(false);
+		});
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	describe('determineRoundWinnerAndPoints', () => {
+		describe('blocked rounds (isBlocked: true)', () => {
+			it('should pick the player with the fewest leftover points as winner', () => {
+				const { determineRoundWinnerAndPoints } = useRules();
+				const playerAId = generateId();
+				const playerBId = generateId();
+
+				const result = determineRoundWinnerAndPoints(
+					{ [playerAId]: 5, [playerBId]: 10 },
+					true
+				);
+
+				expect(result.winnerId).toBe(playerAId);
+			});
+
+			it('should award the winner the sum of others\' points minus their own', () => {
+				const { determineRoundWinnerAndPoints } = useRules();
+				const playerAId = generateId();
+				const playerBId = generateId();
+
+				// A=5, B=10 → A wins, gets 10 - 5 = 5
+				const result = determineRoundWinnerAndPoints(
+					{ [playerAId]: 5, [playerBId]: 10 },
+					true
+				);
+
+				expect(result.points).toBe(5);
+			});
+
+			it('should handle three players correctly', () => {
+				const { determineRoundWinnerAndPoints } = useRules();
+				const playerAId = generateId();
+				const playerBId = generateId();
+				const playerCId = generateId();
+
+				// A=5, B=10, C=15 → A wins, gets 10 + 15 - 5 = 20
+				const result = determineRoundWinnerAndPoints(
+					{ [playerAId]: 5, [playerBId]: 10, [playerCId]: 15 },
+					true
+				);
+
+				expect(result.winnerId).toBe(playerAId);
+				expect(result.points).toBe(20);
+			});
+
+			it('should award 0 points when all players have 0 leftover', () => {
+				const { determineRoundWinnerAndPoints } = useRules();
+				const playerAId = generateId();
+				const playerBId = generateId();
+
+				const result = determineRoundWinnerAndPoints(
+					{ [playerAId]: 0, [playerBId]: 0 },
+					true
+				);
+
+				expect(result.points).toBe(0);
+			});
+
+			it('should pick the first player in iteration order when leftover points are tied', () => {
+				const { determineRoundWinnerAndPoints } = useRules();
+				const playerAId = generateId();
+				const playerBId = generateId();
+
+				// A and B are tied at 5 points each. The reduce initializes
+				// with playerIds[0] (A) and only replaces on strict <, so A
+				// wins.
+				// Points awarded: 5 - 5 = 0.
+				const result = determineRoundWinnerAndPoints(
+					{ [playerAId]: 5, [playerBId]: 5 },
+					true
+				);
+
+				expect(result.winnerId).toBe(playerAId);
+				expect(result.points).toBe(0);
+			});
+		});
+
+		describe('won rounds (isBlocked: false)', () => {
+			it('should award the winner 25 base points plus all leftover points from other players', () => {
+				const { determineRoundWinnerAndPoints } = useRules();
+				const playerAId = generateId();
+				const playerBId = generateId();
+
+				// B=10 leftover, winner A → 25 + 10 = 35
+				const result = determineRoundWinnerAndPoints(
+					{ [playerBId]: 10 },
+					false,
+					playerAId
+				);
+
+				expect(result.winnerId).toBe(playerAId);
+				expect(result.points).toBe(35);
+			});
+
+			it('should sum all players\' leftover points', () => {
+				const { determineRoundWinnerAndPoints } = useRules();
+				const playerAId = generateId();
+				const playerBId = generateId();
+				const playerCId = generateId();
+
+				// B=10, C=20 leftover, winner A → 25 + 10 + 20 = 55
+				const result = determineRoundWinnerAndPoints(
+					{ [playerBId]: 10, [playerCId]: 20 },
+					false,
+					playerAId
+				);
+
+				expect(result.points).toBe(55);
+			});
+
+			it('should award exactly 25 points when all others have 0 leftover', () => {
+				const { determineRoundWinnerAndPoints } = useRules();
+				const playerAId = generateId();
+				const playerBId = generateId();
+				const playerCId = generateId();
+
+				const result = determineRoundWinnerAndPoints(
+					{ [playerBId]: 0, [playerCId]: 0 },
+					false,
+					playerAId
+				);
+
+				expect(result.points).toBe(25);
+			});
+		});
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	describe('determineStonesPerPlayer', () => {
+		it('should return 9 when the number of players is 2', () => {
+			const { determineStonesPerPlayer } = useRules();
+			expect(determineStonesPerPlayer(2)).toBe(9);
+		});
+
+		it('should return 7 when the number of players is 3 or 4', () => {
+			const { determineStonesPerPlayer } = useRules();
+			expect(determineStonesPerPlayer(3)).toBe(7);
+			expect(determineStonesPerPlayer(4)).toBe(7);
+		});
+
+		it('should return 6 when the number of players is 5 or 6', () => {
+			const { determineStonesPerPlayer } = useRules();
+			expect(determineStonesPerPlayer(5)).toBe(6);
+			expect(determineStonesPerPlayer(6)).toBe(6);
+		});
+
+		it('should return 0 when the number of players is not 2, 3, 4, 5, or 6', () => {
+			const { determineStonesPerPlayer } = useRules();
+			expect(determineStonesPerPlayer(1)).toBe(0);
+			expect(determineStonesPerPlayer(7)).toBe(0);
+		});
+	});
+});

--- a/src/composables/useRules.ts
+++ b/src/composables/useRules.ts
@@ -1,10 +1,3 @@
-import { computed } from 'vue';
-import { storeToRefs } from 'pinia';
-
-import { usePlayersStore } from '@/stores/players';
-
-/* ========================================================================== */
-
 /**
  * The points to be awarded to the winner of a round.
  */
@@ -41,14 +34,6 @@ const scoreModifiers = {
 /* ========================================================================== */
 
 export function useRules() {
-	const playerStore = usePlayersStore();
-
-	/* ---------------------------------------------------------------------- */
-
-	const { activePlayers } = storeToRefs(playerStore);
-
-	/* ---------------------------------------------------------------------- */
-
 	function determineBlockedRoundWinnerAndPoints(leftoverPoints: Record<Id, number>): RoundEndPoints {
 		const playerIds = Object.keys(leftoverPoints) as Id[];
 		// The player with the least points is the winner of a blocked round.
@@ -111,6 +96,26 @@ export function useRules() {
 	}
 
 	/**
+	 * Calculates the number of starting stones per player based on the number
+	 * of active players. When there are no active players, it defaults to 0.
+	 */
+	function determineStonesPerPlayer(numberOfPlayers: number): number {
+		if (numberOfPlayers === 2) return 9;
+
+		if (
+			numberOfPlayers === 3 ||
+			numberOfPlayers === 4
+		) return 7;
+
+		if (
+			numberOfPlayers === 5 ||
+			numberOfPlayers === 6
+		) return 6;
+
+		return 0;
+	}
+
+	/**
 	 * Calculates the bonus score a player receives for the played tile in the
 	 * opening turn of a round.
 	 *
@@ -131,26 +136,6 @@ export function useRules() {
 	function canTileBeTripleStone(value: number): boolean {
 		return value % 3 === 0;
 	}
-
-	/**
-	 * Calculates the number of starting stones based on the number of
-	 * active players. When there are no active players, it defaults to 0.
-	 */
-	const startingStoneCount = computed<number>(() => {
-		if (activePlayers.value.length === 2) return 9;
-
-		if (
-			activePlayers.value.length === 3 ||
-			activePlayers.value.length === 4
-		) return 7;
-
-		if (
-			activePlayers.value.length === 5 ||
-			activePlayers.value.length === 6
-		) return 6;
-
-		return 0;
-	});
 
 	function calculateTurnScore(turn: TurnInput): number {
 		const hasPlayedTile = turn.tilesPlayed === 1;
@@ -189,8 +174,8 @@ export function useRules() {
 		calculateTurnScore,
 		canTileBeTripleStone,
 		determineRoundWinnerAndPoints,
+		determineStonesPerPlayer,
 		maximumNumberOfPlayers,
-		minimumNumberOfPlayers,
-		startingStoneCount
+		minimumNumberOfPlayers
 	};
 }

--- a/src/screens/StartingPlayerScreen.vue
+++ b/src/screens/StartingPlayerScreen.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { usePlayersStore } from '@/stores/players';
@@ -28,7 +28,11 @@ const playerStore = usePlayersStore();
 
 const { activePlayers } = storeToRefs(playerStore);
 
-const { startingStoneCount } = useRules();
+const { determineStonesPerPlayer } = useRules();
+
+const stonesPerPlayer = computed<number>(
+	() => determineStonesPerPlayer(activePlayers.value.length)
+);
 
 const selectedId = ref<Id | undefined>(undefined);
 const showValidationMessage = ref<boolean>(false);
@@ -57,7 +61,7 @@ function onNavigateForward(): void {
 <template>
 	<AppScreen :title="$t('playerSelect.title', [currentRoundOrdinal ?? 0])">
 		<MessageBox>
-			<div v-html="$t('playerSelect.infoMessage', [startingStoneCount])" />
+			<div v-html="$t('playerSelect.infoMessage', [stonesPerPlayer])" />
 		</MessageBox>
 
 		<ToggleButtonGroup


### PR DESCRIPTION
`useRules` held a `computed` ref for `startingStoneCount` that required
importing `usePlayersStore` — coupling a pure rules composable to the
player store purely to read `activePlayers.length`. Because the value
only depends on a number, there is no need for reactivity at the call
site.

Changes:
- Replace `startingStoneCount` (computed, store-dependent) with
  `determineStonesPerPlayer(n)` (pure function taking a player count)
- Remove the `usePlayersStore` and `storeToRefs` imports from `useRules`
- Update `useRoundsLogic` and `StartingPlayerScreen` to call
  `determineStonesPerPlayer` directly with `activePlayers.length`
- Add a `computed` wrapper in `StartingPlayerScreen` to preserve
  reactivity at the component level
- Add a full unit test suite for `useRules` covering all exported
  functions and edge cases