### PR TITLE
refactor(ScoreLeaderboard): decouple from useRoundManager and useRoundsStore

### DIFF
--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -10,6 +10,7 @@ import ScoreLeaderboard from '@/components/ScoreLeaderboard.vue';
 import SettingsPanel from '@/components/SettingsPanel.vue';
 
 import { useBuildInfo } from '@/composables/useBuildInfo';
+import { useRoundManager } from '@/composables/useRoundManager';
 
 /* ========================================================================== */
 
@@ -18,6 +19,7 @@ const emit = defineEmits<{ resetConfirmed: [] }>();
 /* ========================================================================== */
 
 const { hasActiveGame } = storeToRefs(useGameStore());
+const { currentPlayer, tilesPerPlayer } = useRoundManager();
 const { appVersion, formattedBuildTimestamp } = useBuildInfo();
 
 /* -------------------------------------------------------------------------- */
@@ -83,8 +85,8 @@ function onClose(): void {
 				class="container"
 			>
 				<ScoreLeaderboard
-					:highlight-current-player="true"
-					:show-tiles="true"
+					:current-player-id="currentPlayer?.id"
+					:tiles-per-player="tilesPerPlayer"
 				/>
 			</div>
 			<div

--- a/src/components/ScoreLeaderboard.vue
+++ b/src/components/ScoreLeaderboard.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { storeToRefs } from 'pinia';
 
 import { useGameScores } from '@/composables/useGameScores';
 import { usePlayerManager } from '@/composables/usePlayerManager';
-
-import { useRoundsStore } from '@/stores/rounds';
-import { useRoundManager } from '@/composables/useRoundManager';
 
 /* ========================================================================== */
 
@@ -19,44 +15,45 @@ type LeaderboardEntry = {
 
 /* ========================================================================== */
 
-defineProps<{
-	highlightCurrentPlayer?: boolean;
+const props = defineProps<{
+	/**
+	 * Optional prop to specify the current player. When provided the player
+	 * will be highlighted in the leaderboard.
+	 */
+	currentPlayerId?: Id;
 
 	/**
-	 * Determines whether to show the tiles column in the leaderboard.
+	 * When provided, the leaderboard will show per player how many tiles they
+	 * have left in their hand.
 	 */
-	showTiles?: boolean;
+	tilesPerPlayer?: TilesPerPlayer;
 }>();
 
 /* ========================================================================== */
 
 const { totalScore } = useGameScores();
 const { players } = usePlayerManager();
-const { currentPlayer } = useRoundManager();
 
-const { currentRound } = storeToRefs(useRoundsStore());
+const showTiles = computed<boolean>(() => props.tilesPerPlayer !== undefined);
 
 /* -------------------------------------------------------------------------- */
 
 const leaderboardData = computed<LeaderboardEntry[]>(() => {
 	return players.value.map(player => {
-		const stats = currentRound.value?.playerStats.find(stat => stat.id === player.id);
+		const tiles = showTiles.value ? (props.tilesPerPlayer?.[player.id] ?? 0) : 0;
 
 		return {
 			id: player.id,
 			name: player.name,
 			score: totalScore.value[player.id],
-			tiles: stats?.tiles ?? 0
+			tiles
 		};
 	}).sort((a, b) => b.score - a.score);
 });
 </script>
 
 <template>
-	<table
-		class="leaderboard"
-		:class="{ 'highlight-current-player': highlightCurrentPlayer }"
-	>
+	<table class="leaderboard">
 		<thead>
 			<tr>
 				<th class="header-cell">
@@ -81,7 +78,7 @@ const leaderboardData = computed<LeaderboardEntry[]>(() => {
 				v-for="(entry, index) of leaderboardData"
 				:key="entry.id"
 				class="player-row"
-				:class="{ 'is-current-player': entry.id === currentPlayer?.id }"
+				:class="{ 'is-current-player': entry.id === currentPlayerId }"
 			>
 				<td>{{ index + 1 }}</td>
 				<td class="name-cell">
@@ -110,13 +107,11 @@ const leaderboardData = computed<LeaderboardEntry[]>(() => {
 	td, th {
 		padding: 2px 10px;
 	}
+}
 
-	&.highlight-current-player {
-		.is-current-player td {
-			font-size: 1.05em;
-			font-weight: bold;
-		}
-	}
+.is-current-player td {
+	font-size: 1.05em;
+	font-weight: bold;
 }
 
 .name-cell {

--- a/src/composables/useRoundManager.ts
+++ b/src/composables/useRoundManager.ts
@@ -42,6 +42,15 @@ export function useRoundManager() {
 		return currentRound.value?.phase ?? 'player-select';
 	});
 
+	const tilesPerPlayer = computed<TilesPerPlayer | undefined>(() => {
+		if (currentRound.value === undefined) return undefined;
+
+		return currentRound.value.playerStats.reduce((acc, player) => {
+			acc[player.id] = player.tiles;
+			return acc;
+		}, {} as TilesPerPlayer);
+	});
+
 	/* ---------------------------------------------------------------------- */
 
 	/**
@@ -199,6 +208,7 @@ export function useRoundManager() {
 		isFirstTurnOfRound,
 		finishRound,
 		setStartingPlayer,
-		saveTurn
+		saveTurn,
+		tilesPerPlayer
 	};
 }

--- a/src/screens/GameResultScreen.vue
+++ b/src/screens/GameResultScreen.vue
@@ -29,7 +29,7 @@ function onContinue() {
 			The game is over. The winner is {{ winner?.name }} with the highest score.
 		</MessageBox>
 
-		<ScoreLeaderboard :show-tiles="false" />
+		<ScoreLeaderboard />
 
 		<template #primary-action>
 			<button

--- a/src/types/TilesPerPlayer.ts
+++ b/src/types/TilesPerPlayer.ts
@@ -1,0 +1,19 @@
+export {};
+
+/* ========================================================================== */
+
+declare global {
+	/**
+	 * Represents the number of tiles each player has in their hands in the
+	 * current round. The keys are player IDs, and the values are the number of
+	 * tiles each player has in their hands.
+	 *
+	 * @example {
+	 *     '123e4567-e89b-12d3-a456-426614174000': 4,
+	 *     ...
+	 * }
+	 */
+	type TilesPerPlayer = {
+		[id: Id]: number;
+	};
+}


### PR DESCRIPTION
ScoreLeaderboard was calling useRoundManager() to get the current player
for row highlighting and reading currentRound directly from useRoundsStore
for tile counts. This made the component context-dependent: rendering it
outside an active round silently produced wrong values.

The component now receives currentPlayerId and tilesPerPlayer as optional
props. When neither is passed the highlighting is inactive and the tiles
column is hidden, which is the correct behaviour in GameResultScreen.

The tilesPerPlayer derivation moved into useRoundManager, where
currentRound is already available. MainMenu derives both values from the
composable and passes them down. A TilesPerPlayer global type was added
to name the shape used across the prop and the composable's return value.