### PR TITLE
refactor(scoring): move score aggregation out of the rounds store

### DIFF
--- a/src/composables/useGameScores.test.ts
+++ b/src/composables/useGameScores.test.ts
@@ -8,7 +8,7 @@ import { usePlayersStore } from '@/stores/players';
 
 /* ========================================================================== */
 
-function createGame(limit: number = 100): void {
+function createGame(limit: number): void {
 	useGameStore().createNewGame(limit);
 }
 
@@ -143,27 +143,106 @@ describe('useGameScores', () => {
 	/* ---------------------------------------------------------------------- */
 
 	describe('totalScore', () => {
-		it('should combine scores from completed and current rounds', () => {
+		it('should return an empty object if there are no rounds', () => {
+			const { totalScore } = useGameScores();
+
+			expect(totalScore.value).toEqual({});
+		});
+
+		it('should return the accumulated scores from completed rounds only', () => {
 			const { totalScore } = useGameScores();
 			const playerId = generateId();
 
-			createGame(200);
 			createRounds([
 				{
 					id: generateId(),
 					isCurrentRound: false,
-					scores: { [playerId]: 60 },
+					scores: { [playerId]: 42 },
+					winnerId: playerId
+				},
+				{
+					id: generateId(),
+					isCurrentRound: false,
+					scores: { [playerId]: 13 },
+					winnerId: playerId
+				}
+			]);
+
+			expect(totalScore.value).toEqual({ [playerId]: 55 });
+		});
+
+		it('should return accumulated scores per player from completed rounds', () => {
+			const { totalScore } = useGameScores();
+			const player1Id = generateId();
+			const player2Id = generateId();
+
+			createRounds([
+				{
+					id: generateId(),
+					isCurrentRound: false,
+					scores: { [player1Id]: 42, [player2Id]: 30 },
+					winnerId: player1Id
+				},
+				{
+					id: generateId(),
+					isCurrentRound: false,
+					scores: { [player1Id]: 13, [player2Id]: 20 },
+					winnerId: player2Id
+				}
+			]);
+
+			expect(totalScore.value).toEqual({
+				[player1Id]: 55,
+				[player2Id]: 50
+			});
+		});
+
+		it('should return the combined scores from completed and current rounds', () => {
+			const { totalScore } = useGameScores();
+			const playerId = generateId();
+
+			createRounds([
+				{
+					id: generateId(),
+					isCurrentRound: false,
+					scores: { [playerId]: 42 },
 					winnerId: playerId
 				},
 				{
 					id: generateId(),
 					isCurrentRound: true,
 					phase: 'turns',
-					playerStats: [{ id: playerId, score: 25, tiles: 2 }]
+					playerStats: [{ id: playerId, score: 10, tiles: 3 }]
 				}
 			]);
 
-			expect(totalScore.value[playerId]).toBe(85);
+			expect(totalScore.value).toEqual({ [playerId]: 52 });
+		});
+
+		it('should return combined scores per player from completed and current rounds', () => {
+			const { totalScore } = useGameScores();
+			const player1Id = generateId();
+			const player2Id = generateId();
+
+			createRounds([
+				{
+					id: generateId(),
+					isCurrentRound: false,
+					scores: { [player1Id]: 42, [player2Id]: 30 },
+					winnerId: player1Id
+				},
+				{
+					id: generateId(),
+					isCurrentRound: true,
+					phase: 'turns',
+					playerStats: [{ id: player1Id, score: 10, tiles: 3 }, { id: player2Id, score: 15, tiles: 3 }]
+				}
+			]);
+
+			expect(totalScore.value).toEqual({
+				[player1Id]: 52,
+				[player2Id]: 45
+			});
 		});
 	});
 
@@ -172,11 +251,8 @@ describe('useGameScores', () => {
 	describe('winner', () => {
 		it('should return undefined when the points limit has not been reached', () => {
 			const { winner } = useGameScores();
-			const playersStore = usePlayersStore();
-			const player: Player = { active: true, id: generateId(), name: 'Alice' };
 
 			createGame(100);
-			playersStore.addPlayer(player);
 
 			expect(winner.value).toBeUndefined();
 		});

--- a/src/composables/useGameScores.test.ts
+++ b/src/composables/useGameScores.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useGameScores } from './useGameScores';
+import { useGameStore } from '@/stores/game';
+import { useRoundsStore } from '@/stores/rounds';
+import { generateId } from '@/utilities/id';
+import { createPinia, setActivePinia } from 'pinia';
+import { usePlayersStore } from '@/stores/players';
+
+/* ========================================================================== */
+
+function createGame(limit: number = 100): void {
+	useGameStore().createNewGame(limit);
+}
+
+function createRounds(rounds: Round[]): void {
+	useRoundsStore().$patch({ rounds });
+}
+
+/* -------------------------------------------------------------------------- */
+
+beforeEach(() => setActivePinia(createPinia()));
+
+/* -------------------------------------------------------------------------- */
+
+describe('useGameScores', () => {
+	describe('hasReachedPointsLimit', () => {
+		it('should return false when there are no player scores', () => {
+			const { hasReachedPointsLimit } = useGameScores();
+
+			createGame(100);
+
+			expect(hasReachedPointsLimit.value).toBe(false);
+		});
+
+		it('should return false when the points limit has not been reached', () => {
+			const { hasReachedPointsLimit } = useGameScores();
+			const playerId1 = generateId();
+			const playerId2 = generateId();
+
+			createGame(100);
+			createRounds([{
+				id: generateId(),
+				isCurrentRound: false,
+				scores: { [playerId1]: 40, [playerId2]: 60 },
+				winnerId: playerId1
+			}]);
+
+			expect(hasReachedPointsLimit.value).toBe(false);
+		});
+
+		it('should return true when a score has exactly reached the points limit', () => {
+			const { hasReachedPointsLimit } = useGameScores();
+			const playerId = generateId();
+
+			createGame(100);
+			createRounds([{
+				id: generateId(),
+				isCurrentRound: false,
+				scores: { [playerId]: 100 },
+				winnerId: playerId
+			}]);
+
+			expect(hasReachedPointsLimit.value).toBe(true);
+		});
+
+		it('should return true when a score exceeds the points limit', () => {
+			const { hasReachedPointsLimit } = useGameScores();
+			const playerId = generateId();
+
+			createGame(100);
+			createRounds([{
+				id: generateId(),
+				isCurrentRound: false,
+				scores: { [playerId]: 120 },
+				winnerId: playerId
+			}]);
+
+			expect(hasReachedPointsLimit.value).toBe(true);
+		});
+
+		it('should consider scores accumulated across multiple completed rounds', () => {
+			const { hasReachedPointsLimit } = useGameScores();
+			const playerId = generateId();
+
+			createGame(100);
+			createRounds([
+				{
+					id: generateId(),
+					isCurrentRound: false,
+					scores: { [playerId]: 60 },
+					winnerId: playerId
+				},
+				{
+					id: generateId(),
+					isCurrentRound: false,
+					scores: { [playerId]: 50 },
+					winnerId: playerId
+				}
+			]);
+
+			expect(hasReachedPointsLimit.value).toBe(true);
+		});
+
+		it('should include the current round scores in the calculation', () => {
+			const { hasReachedPointsLimit } = useGameScores();
+			const playerId = generateId();
+
+			createGame(100);
+			createRounds([{
+				id: generateId(),
+				isCurrentRound: true,
+				phase: 'turns',
+				playerStats: [{ id: playerId, score: 105, tiles: 3 }]
+			}]);
+
+			expect(hasReachedPointsLimit.value).toBe(true);
+		});
+
+		it('should return true when combined completed and current round scores reach the limit', () => {
+			const { hasReachedPointsLimit } = useGameScores();
+			const playerId = generateId();
+
+			createGame(100);
+			createRounds([
+				{
+					id: generateId(),
+					isCurrentRound: false,
+					scores: { [playerId]: 60 },
+					winnerId: playerId
+				},
+				{
+					id: generateId(),
+					isCurrentRound: true,
+					phase: 'turns',
+					playerStats: [{ id: playerId, score: 40, tiles: 3 }]
+				}
+			]);
+
+			expect(hasReachedPointsLimit.value).toBe(true);
+		});
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	describe('totalScore', () => {
+		it('should combine scores from completed and current rounds', () => {
+			const { totalScore } = useGameScores();
+			const playerId = generateId();
+
+			createGame(200);
+			createRounds([
+				{
+					id: generateId(),
+					isCurrentRound: false,
+					scores: { [playerId]: 60 },
+					winnerId: playerId
+				},
+				{
+					id: generateId(),
+					isCurrentRound: true,
+					phase: 'turns',
+					playerStats: [{ id: playerId, score: 25, tiles: 2 }]
+				}
+			]);
+
+			expect(totalScore.value[playerId]).toBe(85);
+		});
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	describe('winner', () => {
+		it('should return undefined when the points limit has not been reached', () => {
+			const { winner } = useGameScores();
+			const playersStore = usePlayersStore();
+			const player: Player = { active: true, id: generateId(), name: 'Alice' };
+
+			createGame(100);
+			playersStore.addPlayer(player);
+
+			expect(winner.value).toBeUndefined();
+		});
+
+		it('should return undefined when the winning player ID is not found in the players store', () => {
+			const { winner } = useGameScores();
+			const playerId = generateId();
+
+			createGame(100);
+			// Intentionally not adding the player to the players store.
+			createRounds([{
+				id: generateId(),
+				isCurrentRound: false,
+				scores: { [playerId]: 120 },
+				winnerId: playerId
+			}]);
+
+			expect(winner.value).toBeUndefined();
+		});
+
+		it('should return the player with the highest score when the limit is reached', () => {
+			const { winner } = useGameScores();
+			const playersStore = usePlayersStore();
+			const player1: Player = { active: true, id: generateId(), name: 'Alice' };
+			const player2: Player = { active: true, id: generateId(), name: 'Bob' };
+
+			createGame(100);
+			playersStore.addPlayer(player1);
+			playersStore.addPlayer(player2);
+			createRounds([{
+				id: generateId(),
+				isCurrentRound: false,
+				scores: { [player1.id]: 120, [player2.id]: 80 },
+				winnerId: player1.id
+			}]);
+
+			expect(winner.value).toMatchObject({ id: player1.id, name: 'Alice' });
+		});
+	});
+});

--- a/src/composables/useGameScores.ts
+++ b/src/composables/useGameScores.ts
@@ -12,23 +12,57 @@ export function useGameScores() {
 	const roundsStore = useRoundsStore();
 	const playersStore = usePlayersStore();
 
-	/* ---------------------------------------------------------------------- */
-
 	const { pointsLimit } = storeToRefs(gameStore);
-	const { playerScores } = storeToRefs(roundsStore);
+	const { currentRound, completedRounds } = storeToRefs(roundsStore);
+
+	/* -- Score Aggregation ------------------------------------------------- */
+
+	const currentRoundScore = computed<ScorePerPlayer>(() => {
+		if (currentRound.value === undefined) return {};
+
+		return currentRound.value.playerStats.reduce((acc, playerStat) => {
+			acc[playerStat.id] = playerStat.score;
+			return acc;
+		}, {} as ScorePerPlayer);
+	});
+
+	const finishedRoundsScore = computed<ScorePerPlayer>(() => {
+		return completedRounds.value.reduce((acc, round) => {
+			(Object.keys(round.scores) as Id[]).forEach((playerId) => {
+				acc[playerId] = (acc[playerId] ?? 0) + round.scores[playerId];
+			});
+
+			return acc;
+		}, {} as ScorePerPlayer);
+	});
+
+	const totalScore = computed<ScorePerPlayer>(() => {
+		const keys = new Set<Id>([
+			...Object.keys(currentRoundScore.value) as Id[],
+			...Object.keys(finishedRoundsScore.value) as Id[]
+		]);
+
+		const result: ScorePerPlayer = {};
+		keys.forEach((key) => {
+			result[key] =
+				(currentRoundScore.value[key] ?? 0) + (finishedRoundsScore.value[key] ?? 0);
+		});
+
+		return result;
+	});
+
+	/* -- Game State -------------------------------------------------------- */
 
 	const hasReachedPointsLimit = computed<boolean>(() => {
-		const scores = Object.values(playerScores.value);
+		const scores = Object.values(totalScore.value);
 
 		return Math.max(...scores) >= pointsLimit.value;
 	});
 
-	/* ---------------------------------------------------------------------- */
-
 	const winningPlayerId = computed<Id | undefined>(() => {
 		if (!hasReachedPointsLimit.value) return undefined;
 
-		const [winner, ...players] = Object.entries(playerScores.value) as [Id, number][];
+		const [winner, ...players] = Object.entries(totalScore.value) as [Id, number][];
 
 		return players.reduce((winner, player) =>
 			player[1] > winner[1] ? player : winner
@@ -45,17 +79,19 @@ export function useGameScores() {
 
 	return {
 		/**
-		 * Indicates whether the points limit has been reached.
+		 * Indicates whether the points limit for the game has been reached.
 		 */
 		hasReachedPointsLimit,
 
 		/**
 		 * The points scored, per player, over the completed and current rounds.
 		 */
-		totalScore: playerScores,
+		totalScore,
 
 		/**
-		 * The player who has won the game.
+		 * The player who has won the game. Is undefined as long as the points
+		 * limit has not been reached or the winner is not found in the
+		 * players store.
 		 */
 		winner
 	};

--- a/src/stores/rounds.test.ts
+++ b/src/stores/rounds.test.ts
@@ -373,52 +373,6 @@ describe('Rounds Store', () => {
 
 	/* ---------------------------------------------------------------------- */
 
-	describe('currentRoundScore', () => {
-		it('should return an empty object if there is no current round', () => {
-			const roundsStore = useRoundsStore();
-
-			expect(roundsStore.currentRoundScore).toEqual({});
-		});
-
-		it('should return an empty object if the current round has no players', () => {
-			const roundsStore = useRoundsStore();
-
-			roundsStore.addRound(createCurrentRound());
-
-			expect(roundsStore.currentRoundScore).toEqual({});
-		});
-
-		it('should return a score of 0 for each player when no scores have been recorded', () => {
-			const roundsStore = useRoundsStore();
-			const playerA = generateId();
-			const playerB = generateId();
-
-			roundsStore.addRound(createCurrentRound([playerA, playerB]));
-
-			expect(roundsStore.currentRoundScore).toEqual({
-				[playerA]: 0,
-				[playerB]: 0
-			});
-		});
-
-		it('should reflect scores updated via updateCurrentRoundPlayerStats', () => {
-			const roundsStore = useRoundsStore();
-			const playerA = generateId();
-			const playerB = generateId();
-
-			roundsStore.addRound(createCurrentRound([playerA, playerB]));
-			roundsStore.updateCurrentRoundPlayerStats(playerA, 0, 15);
-			roundsStore.updateCurrentRoundPlayerStats(playerB, 0, 7);
-
-			expect(roundsStore.currentRoundScore).toEqual({
-				[playerA]: 15,
-				[playerB]: 7
-			});
-		});
-	});
-
-	/* ---------------------------------------------------------------------- */
-
 	describe('getCurrentRoundTileCountForPlayer', () => {
 		it('should throw an error if there is no current round', () => {
 			const roundsStore = useRoundsStore();
@@ -465,81 +419,6 @@ describe('Rounds Store', () => {
 			roundsStore.addRound(createCurrentRound());
 
 			expect(roundsStore.hasCurrentRound).toBe(true);
-		});
-	});
-
-	/* ---------------------------------------------------------------------- */
-
-	describe('playerScores', () => {
-		it('should return an empty object if there are no rounds', () => {
-			const roundsStore = useRoundsStore();
-
-			expect(roundsStore.playerScores).toEqual({});
-		});
-
-		it('should return the accumulated scores from completed rounds only', () => {
-			const roundsStore = useRoundsStore();
-			const playerId = generateId();
-
-			roundsStore.addRound(createCurrentRound([playerId]));
-			roundsStore.updateCurrentRound({ winnerId: playerId });
-			roundsStore.completeCurrentRound({ [playerId]: 42 });
-
-			roundsStore.addRound(createCurrentRound([playerId]));
-			roundsStore.updateCurrentRound({ winnerId: playerId });
-			roundsStore.completeCurrentRound({ [playerId]: 13 });
-
-			expect(roundsStore.playerScores).toEqual({ [playerId]: 55 });
-		});
-
-		it('should return accumulated scores per player from completed rounds', () => {
-			const roundsStore = useRoundsStore();
-			const player1Id = generateId();
-			const player2Id = generateId();
-
-			roundsStore.addRound(createCurrentRound([player1Id, player2Id]));
-			roundsStore.updateCurrentRound({ winnerId: player1Id });
-			roundsStore.completeCurrentRound({ [player1Id]: 42, [player2Id]: 30 });
-			roundsStore.addRound(createCurrentRound([player1Id, player2Id]));
-			roundsStore.updateCurrentRound({ winnerId: player2Id });
-			roundsStore.completeCurrentRound({ [player1Id]: 13, [player2Id]: 20 });
-
-			expect(roundsStore.playerScores).toEqual({
-				[player1Id]: 55,
-				[player2Id]: 50
-			});
-		});
-
-		it('should return the combined scores from completed and current rounds', () => {
-			const roundsStore = useRoundsStore();
-			const playerId = generateId();
-
-			roundsStore.addRound(createCurrentRound([playerId]));
-			roundsStore.updateCurrentRound({ winnerId: playerId });
-			roundsStore.completeCurrentRound({ [playerId]: 42 });
-
-			roundsStore.addRound(createCurrentRound([playerId]));
-			roundsStore.updateCurrentRoundPlayerStats(playerId, 0, 10);
-
-			expect(roundsStore.playerScores).toEqual({ [playerId]: 52 });
-		});
-
-		it('should return combined scores per player from completed and current rounds', () => {
-			const roundsStore = useRoundsStore();
-			const player1Id = generateId();
-			const player2Id = generateId();
-
-			roundsStore.addRound(createCurrentRound([player1Id, player2Id]));
-			roundsStore.updateCurrentRound({ winnerId: player1Id });
-			roundsStore.completeCurrentRound({ [player1Id]: 42, [player2Id]: 30 });
-			roundsStore.addRound(createCurrentRound([player1Id, player2Id]));
-			roundsStore.updateCurrentRoundPlayerStats(player1Id, 0, 10);
-			roundsStore.updateCurrentRoundPlayerStats(player2Id, 0, 15);
-
-			expect(roundsStore.playerScores).toEqual({
-				[player1Id]: 52,
-				[player2Id]: 45
-			});
 		});
 	});
 

--- a/src/stores/rounds.ts
+++ b/src/stores/rounds.ts
@@ -85,40 +85,6 @@ export const useRoundsStore = defineStore('round', () => {
 		return playerStats.tiles;
 	}
 
-	const currentRoundScore = computed<Record<Id, number>>(() => {
-		if (currentRound.value === undefined) return {};
-
-		return currentRound.value.playerStats.reduce((acc, playerStat) => {
-			acc[playerStat.id] = playerStat.score;
-			return acc;
-		}, {} as Record<Id, number>);
-	});
-
-	const finishedRoundsScore = computed<Record<Id, number>>(() => {
-		return completedRounds.value.reduce((acc, round) => {
-			(Object.keys(round.scores) as Id[]).forEach((playerId) => {
-				acc[playerId] = (acc[playerId] ?? 0) + round.scores[playerId];
-			});
-
-			return acc;
-		}, {} as Record<Id, number>);
-	});
-
-	const playerScores = computed<Record<Id, number>>(() => {
-		const keys = new Set<Id>([
-			...Object.keys(currentRoundScore.value) as Id[],
-			...Object.keys(finishedRoundsScore.value) as Id[]
-		]);
-
-		const result: Record<Id, number> = {};
-		keys.forEach((key) => {
-			result[key] =
-				(currentRoundScore.value[key] ?? 0) + (finishedRoundsScore.value[key] ?? 0);
-		});
-
-		return result;
-	});
-
 	/* ---------------------------------------------------------------------- */
 
 	/**
@@ -317,10 +283,8 @@ export const useRoundsStore = defineStore('round', () => {
 		currentPlayerStats,
 		currentRound,
 		currentRoundOrdinal,
-		currentRoundScore,
 		getCurrentRoundTileCountForPlayer,
 		hasCurrentRound,
-		playerScores,
 
 		// Actions
 		$reset,

--- a/src/types/ScorePerPlayer.ts
+++ b/src/types/ScorePerPlayer.ts
@@ -1,0 +1,18 @@
+export {};
+
+/* ========================================================================== */
+
+declare global {
+	/**
+	 * Represents the score of each player. The keys are player IDs, and the
+	 * values are the number of points.
+	 *
+	 * @example {
+	 *     '123e4567-e89b-12d3-a456-426614174000': 4,
+	 *     ...
+	 * }
+	 */
+	type ScorePerPlayer = {
+		[id: Id]: number;
+	};
+}


### PR DESCRIPTION
Moves `finishedRoundsScore` and `playerScores` out of the rounds store
and into `useGameScores`, renaming `playerScores` to `totalScore` in the
process. Introduces a `ScorePerPlayer` type to replace the inline
`Record<Id, number>` used throughout the aggregation logic.

## Why

The rounds store was responsible for game-wide score aggregation, which
sits outside its domain. Moving these computeds into `useGameScores`
gives the composable full ownership of the scoring pipeline and keeps
the rounds store focused on round lifecycle and state.

## Changes

- `useGameScores` now owns `currentRoundScore`, `finishedRoundsScore`,
  and `totalScore`, reading `completedRounds` and `currentRound` from
  the rounds store as inputs
- `playerScores` removed from the rounds store entirely
- `ScorePerPlayer` type extracted to replace ad-hoc `Record<Id, number>`
  annotations
- `useGameScores` covered with a full unit test suite
- `rounds` store `playerScores` tests migrated to `useGameScores.test.ts`
  with multi-player coverage added