### PR TITLE
refactor(turns): remove roundId from Turn and simplify store

### DIFF
--- a/src/composables/useRoundManager.ts
+++ b/src/composables/useRoundManager.ts
@@ -54,19 +54,9 @@ export function useRoundManager() {
 	/* ---------------------------------------------------------------------- */
 
 	/**
-	 * The turns for the current round.
-	 */
-	const turnsForCurrentRound = computed<Turn[]>(() => {
-		const round = currentRound.value;
-		if (round === undefined) return [];
-
-		return turns.value.filter(turn => turn.roundId === round.id);
-	});
-
-	/**
 	 * Indicates whether the current turn is the first turn of the round.
 	 */
-	const isFirstTurnOfRound = computed<boolean>(() => turnsForCurrentRound.value.length === 0);
+	const isFirstTurnOfRound = computed<boolean>(() => turns.value.length === 0);
 
 	/* ---------------------------------------------------------------------- */
 
@@ -91,7 +81,7 @@ export function useRoundManager() {
 	}
 
 	function checkIfRoundIsBlocked(): boolean {
-		const lastTurns = turnsForCurrentRound.value.slice(-playersStore.activePlayers.length);
+		const lastTurns = turns.value.slice(-playersStore.activePlayers.length);
 
 		if (lastTurns.length < playersStore.activePlayers.length) return false;
 
@@ -147,7 +137,7 @@ export function useRoundManager() {
 
 		// Clear the turns for the round which was the current round up to a
 		// moment ago. Once it is finished, its turns are no longer editable.
-		turnsStore.deleteTurnsForRound(round.id);
+		turnsStore.deleteTurns();
 
 		return { success: true };
 	}

--- a/src/composables/useRoundsLogic.ts
+++ b/src/composables/useRoundsLogic.ts
@@ -95,8 +95,7 @@ export function useRoundsLogic() {
 		const turn: Turn = {
 			...turnInput,
 			id: generateId(),
-			playerId: currentPlayerId.value,
-			roundId: currentRound.value.id
+			playerId: currentPlayerId.value
 		};
 
 		// Store the turn in the turns store.

--- a/src/stores/turns.test.ts
+++ b/src/stores/turns.test.ts
@@ -9,11 +9,10 @@ import { useTurnsStore } from './turns';
 
 /* ========================================================================== */
 
-function createTurn(roundId = generateId()): Turn {
+function createTurn(): Turn {
 	return {
 		id: generateId(),
 		playerId: generateId(),
-		roundId,
 		score: 0,
 		tilesDrawn: 3,
 		tilesPlayed: 0,
@@ -42,35 +41,19 @@ describe('Turns Store', () => {
 
 	/* ---------------------------------------------------------------------- */
 
-	describe('deleteTurnsForRound', () => {
-		it('should delete turns for a specific round', () => {
+	describe('deleteTurns', () => {
+		it('should delete all turns', () => {
 			const turnStore = useTurnsStore();
 
-			const roundA = generateId();
-			const turnA = createTurn(roundA);
-
-			const roundB = generateId();
-			const turnB = createTurn(roundB);
+			const turnA = createTurn();
+			const turnB = createTurn();
 
 			turnStore.addTurn(turnA);
 			turnStore.addTurn(turnB);
 
-			turnStore.deleteTurnsForRound(roundA);
+			turnStore.deleteTurns();
 
-			expect(turnStore.turns).toHaveLength(1);
-			expect(turnStore.turns[0]).toEqual(turnB);
-		});
-
-		it('should do nothing if the round ID is not found', () => {
-			const turnStore = useTurnsStore();
-			const turn = createTurn();
-
-			turnStore.addTurn(turn);
-
-			turnStore.deleteTurnsForRound(generateId());
-
-			expect(turnStore.turns).toHaveLength(1);
-			expect(turnStore.turns[0]).toEqual(turn);
+			expect(turnStore.turns).toHaveLength(0);;
 		});
 	});
 

--- a/src/stores/turns.ts
+++ b/src/stores/turns.ts
@@ -7,7 +7,8 @@ import { TurnIdNotFoundError } from '@/errors';
 
 export const useTurnsStore = defineStore('turns', () => {
 	/**
-	 * A list of turns.
+	 * The turns for the current round. Turns from previous rounds are removed
+	 * when a round completes via `deleteTurns`.
 	 */
 	const turns = ref<Turn[]>([]);
 

--- a/src/stores/turns.ts
+++ b/src/stores/turns.ts
@@ -30,12 +30,10 @@ export const useTurnsStore = defineStore('turns', () => {
 	}
 
 	/**
-	 * Deletes all turns associated with a specific round ID.
-	 *
-	 * @param roundId The ID of the round for which to delete turns.
+	 * Deletes all turns from the turns store.
 	 */
-	function deleteTurnsForRound(roundId: Id): void {
-		turns.value = turns.value.filter(turn => turn.roundId !== roundId);
+	function deleteTurns(): void {
+		turns.value = [];
 	}
 
 	/**
@@ -67,7 +65,7 @@ export const useTurnsStore = defineStore('turns', () => {
 		// Actions
 		$reset,
 		addTurn,
-		deleteTurnsForRound,
+		deleteTurns,
 		updateTurn
 	};
 }, {

--- a/src/types/Turn.d.ts
+++ b/src/types/Turn.d.ts
@@ -18,13 +18,6 @@ type TurnBase = {
 	playerId: Id;
 
 	/**
-	 * The ID of the round this turn belongs to.
-	 *
-	 * @example '123e4567-e89b-12d3-a456-426614174000'
-	 */
-	roundId: Id;
-
-	/**
 	 * The total score for this turn after all bonuses and penalties have
 	 * been applied.
 	 *


### PR DESCRIPTION
`roundId` was used to filter turns per round via `turnsForCurrentRound`
in `useRoundManager`. This added complexity across the type, store, and
composable without real benefit: turns are already cleared at round
completion, so the store only ever holds turns for the current round.

- Remove `roundId` from `TurnBase` and all construction sites
- Replace `deleteTurnsForRound` (filter by ID) with `deleteTurns`
  (clear all), which is now the correct and simpler operation
- Remove the `turnsForCurrentRound` computed and replace its two
  usages with direct access to `turns`
- Document the single-round invariant on the `turns` state declaration