### PR TITLE
refactor(collect-points): extract round-end point collection into composable

### DIFF
--- a/src/components/CollectPointsPlayerItem.vue
+++ b/src/components/CollectPointsPlayerItem.vue
@@ -5,7 +5,7 @@ import { computed } from 'vue';
 /* ========================================================================== */
 
 const emit = defineEmits<{
-	(event: 'collect', playerId: Id): void
+	(event: 'collect', player: Player): void
 }>();
 
 const props = defineProps<{
@@ -48,10 +48,10 @@ const message = computed<string>(() => {
 
 /**
  * Handles the click event on the player item button. It will emit a 'collect'
- * event with the player's ID when the button is clicked.
+ * event with the player when the button is clicked.
  */
 function onClick(): void {
-	emit('collect', props.player.id);
+	emit('collect', props.player);
 }
 </script>
 

--- a/src/composables/useCollectPoints.test.ts
+++ b/src/composables/useCollectPoints.test.ts
@@ -1,0 +1,209 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { generateId } from '@/utilities/id';
+
+import { usePlayersStore } from '@/stores/players';
+import { useRoundsStore } from '@/stores/rounds';
+
+import { useCollectPoints } from './useCollectPoints';
+
+/* ========================================================================== */
+
+function createRoundWithPlayers(ids: Id[]): void {
+	const playersStore = usePlayersStore();
+	const roundsStore = useRoundsStore();
+
+	ids.forEach((id) => {
+		playersStore.addPlayer({ active: true, id, name: id });
+	});
+
+	roundsStore.addRound({
+		id: generateId(),
+		isCurrentRound: true,
+		phase: 'round-end',
+		playerStats: ids.map(id => ({ id, score: 0, tiles: 0 }))
+	});
+}
+
+function setWinner(winnerId: Id): void {
+	const roundsStore = useRoundsStore();
+
+	roundsStore.updateCurrentRound({ winnerId });
+}
+
+/* -------------------------------------------------------------------------- */
+
+beforeEach(() => setActivePinia(createPinia()));
+
+/* -------------------------------------------------------------------------- */
+
+describe('useCollectPoints', () => {
+	describe('collectedPoints', () => {
+		it('should be an empty object when there are no active players', () => {
+			const { collectedPoints } = useCollectPoints();
+
+			expect(collectedPoints.value).toEqual({});
+		});
+
+		it('should contain all players when the round is blocked', () => {
+			const playerAId = generateId();
+			const playerBId = generateId();
+			const playerCId = generateId();
+
+			createRoundWithPlayers([playerAId, playerBId, playerCId]);
+			const { collectedPoints } = useCollectPoints();
+
+			expect(collectedPoints.value).toEqual({
+				[playerAId]: undefined,
+				[playerBId]: undefined,
+				[playerCId]: undefined
+			});
+
+		});
+
+		it('should be an object with all the players except the winner', () => {
+			const playerAId = generateId();
+			const playerBId = generateId();
+			const playerCId = generateId();
+
+			createRoundWithPlayers([playerAId, playerBId, playerCId]);
+			setWinner(playerAId);
+
+			const { collectedPoints } = useCollectPoints();
+
+			expect(collectedPoints.value).toEqual({
+				[playerBId]: undefined,
+				[playerCId]: undefined
+			});
+		});
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	describe('hasPlayerWonTheRound', () => {
+		it('should return false when the player is not the winner', () => {
+			const playerAId = generateId();
+
+			createRoundWithPlayers([playerAId]);
+
+			const { hasPlayerWonTheRound } = useCollectPoints();
+
+			expect(hasPlayerWonTheRound(playerAId)).toBe(false);
+		});
+
+		it('should return true when the player is the winner', () => {
+			const playerAId = generateId();
+
+			createRoundWithPlayers([playerAId]);
+			setWinner(playerAId);
+
+			const { hasPlayerWonTheRound } = useCollectPoints();
+
+			expect(hasPlayerWonTheRound(playerAId)).toBe(true);
+		});
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	describe('isComplete', () => {
+		it('should return false as long as a player has not collected points', () => {
+			const playerAId = generateId();
+			const playerBId = generateId();
+			const playerCId = generateId();
+
+			createRoundWithPlayers([playerAId, playerBId, playerCId]);
+
+			const { isComplete } = useCollectPoints();
+
+			expect(isComplete.value).toBe(false);
+		});
+
+		it('should return true when all players have collected points', () => {
+			const playerAId = generateId();
+			const playerBId = generateId();
+			const playerCId = generateId();
+
+			createRoundWithPlayers([playerAId, playerBId, playerCId]);
+
+			const { isComplete, setCollectedPoints } = useCollectPoints();
+
+			setCollectedPoints(playerAId, 10);
+			setCollectedPoints(playerBId, 20);
+			setCollectedPoints(playerCId, 30);
+
+			expect(isComplete.value).toBe(true);
+		});
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	describe('setCollectedPoints', () => {
+		it('should set the collected points for the player', () => {
+			const playerAId = generateId();
+
+			createRoundWithPlayers([playerAId]);
+
+			const { collectedPoints, setCollectedPoints } = useCollectPoints();
+
+			setCollectedPoints(playerAId, 10);
+
+			expect(collectedPoints.value[playerAId]).toBe(10);
+		});
+
+		it('should clear the points for the player when the points are set to undefined', () => {
+			const playerAId = generateId();
+
+			createRoundWithPlayers([playerAId]);
+
+			const { collectedPoints, setCollectedPoints } = useCollectPoints();
+
+			setCollectedPoints(playerAId, 10);
+			setCollectedPoints(playerAId, undefined);
+
+			expect(collectedPoints.value[playerAId]).toBeUndefined();
+		});
+
+		it('should not set the collected points for a player who is not in the round', () => {
+			const playerAId = generateId();
+			const playerBId = generateId();
+
+			createRoundWithPlayers([playerAId]);
+
+			const { collectedPoints, setCollectedPoints } = useCollectPoints();
+
+			setCollectedPoints(playerBId, 10);
+
+			expect(collectedPoints.value[playerBId]).toBeUndefined();
+		});
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	describe('winningPlayerName', () => {
+		it('should return undefined when the round is blocked', () => {
+			const playerAId = generateId();
+			const playerBId = generateId();
+			const playerCId = generateId();
+
+			createRoundWithPlayers([playerAId, playerBId, playerCId]);
+
+			const { winningPlayerName } = useCollectPoints();
+
+			expect(winningPlayerName.value).toBeUndefined();
+		});
+
+		it('should return the name of the winner when the round is not blocked', () => {
+			const playerAId = generateId();
+			const playerBId = generateId();
+			const playerCId = generateId();
+
+			createRoundWithPlayers([playerAId, playerBId, playerCId]);
+			setWinner(playerAId);
+
+			const { winningPlayerName } = useCollectPoints();
+
+			expect(winningPlayerName.value).toEqual(playerAId);
+		});
+	});
+});

--- a/src/composables/useCollectPoints.ts
+++ b/src/composables/useCollectPoints.ts
@@ -1,0 +1,90 @@
+import { computed, readonly, ref } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { usePlayersStore } from '@/stores/players';
+import { useRoundsStore } from '@/stores/rounds';
+
+/* ========================================================================== */
+
+type CollectedPoints = {
+	[id: Id]: number | undefined;
+};
+
+/* ========================================================================== */
+
+export function useCollectPoints() {
+	const playersStore = usePlayersStore();
+
+	const { activePlayers } = storeToRefs(playersStore);
+	const { currentRound } = storeToRefs(useRoundsStore());
+
+	/* ---------------------------------------------------------------------- */
+
+	/**
+	 * During the round-end phase a player can no longer go from active to
+	 * inactive. For this reason it is fine to use a ref to store the points per
+	 * player.
+	 */
+	const collectedPoints = ref<CollectedPoints>(
+		activePlayers.value.reduce((acc, player) => {
+			// The player who has won the round does not need to collect points.
+			if (player.id === currentRound.value?.winnerId) return acc;
+
+			return {
+				...acc,
+				[player.id]: undefined
+			};
+		}, {})
+	);
+
+	const isComplete = computed<boolean>(() => {
+		return Object.values(collectedPoints.value).every((points) => points !== undefined);
+	});
+
+	const winningPlayerName = computed<string | undefined>(() => {
+		if (currentRound.value?.winnerId === undefined) return undefined;
+
+		const player = playersStore.getPlayerById(currentRound.value.winnerId);
+
+		return player?.name;
+	});
+
+	/* ---------------------------------------------------------------------- */
+
+	function hasPlayerWonTheRound(playerId: Id): boolean {
+		return currentRound.value?.winnerId === playerId;
+	}
+
+	function setCollectedPoints(playerId: Id, points: number | undefined): void {
+		if (!Object.hasOwn(collectedPoints.value, playerId)) return;
+
+		collectedPoints.value[playerId] = points;
+	}
+
+	/* ---------------------------------------------------------------------- */
+
+	return {
+		activePlayers,
+
+		/**
+		 * The collected points for each player in the current round. The value
+		 * is undefined as long as the player has not collected points. Do not
+		 * modify the object directly, use the `setCollectedPoints`
+		 * function instead.
+		 */
+		collectedPoints: readonly(collectedPoints),
+
+		hasPlayerWonTheRound,
+
+		isComplete,
+
+		/**
+		 * Sets the collected points for a player in the current round.
+		 * @param points - The number of points to set for the player. If the
+		 *        value is undefined, the points will be cleared for the player.
+		 */
+		setCollectedPoints,
+
+		winningPlayerName
+	};
+}

--- a/src/screens/CollectPointsScreen.vue
+++ b/src/screens/CollectPointsScreen.vue
@@ -1,22 +1,13 @@
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue';
-import { storeToRefs } from 'pinia';
-
-import { usePlayersStore } from '@/stores/players';
-import { useRoundsStore } from '@/stores/rounds';
+import { computed, ref } from 'vue';
 
 import AppScreen from '@/screens/AppScreen.vue';
 import CollectPointsPlayerItem from '@/components/CollectPointsPlayerItem.vue';
 import MessageBox from '@/components/MessageBox.vue';
 import PointsBottomSheet from '@/components/PointsBottomSheet.vue';
+import { useCollectPoints } from '@/composables/useCollectPoints';
 
 /* ========================================================================== */
-
-type CollectingLeftoverPoints = {
-	[id: Id]: number | undefined;
-};
-
-/* -------------------------------------------------------------------------- */
 
 const emit = defineEmits<{
 	(event: 'navigate-forward', leftoverPoints: LeftoverPoints): void;
@@ -24,39 +15,21 @@ const emit = defineEmits<{
 
 /* -------------------------------------------------------------------------- */
 
-const playersStore = usePlayersStore();
-
-const { activePlayers } = storeToRefs(playersStore);
-const { currentRound } = storeToRefs(useRoundsStore());
+const {
+	activePlayers,
+	collectedPoints,
+	hasPlayerWonTheRound,
+	isComplete,
+	setCollectedPoints,
+	winningPlayerName
+} = useCollectPoints();
 
 const isSheetOpen = ref<boolean>(false);
 const selectedPlayer = ref<Player | undefined>(undefined);
 
 const points = ref<number | undefined>(undefined);
 
-const leftOverPointsPerPlayer = reactive<CollectingLeftoverPoints>(activePlayers.value.reduce((acc, player) => {
-	// The player who has won the round does not need to collect points.
-	if (player.id === currentRound.value?.winnerId) return acc;
-
-	return {
-		...acc,
-		[player.id]: undefined
-	};
-}, {}));
-
-const canContinue = computed<boolean>(() => {
-	const points = Object.values(leftOverPointsPerPlayer);
-
-	return points.every((point) => point !== undefined);
-});
-
-const winningPlayerName = computed<string | undefined>(() => {
-	if (currentRound.value?.winnerId === undefined) return undefined;
-
-	const player = playersStore.getPlayerById(currentRound.value.winnerId);
-
-	return player?.name;
-});
+/* -------------------------------------------------------------------------- */
 
 const infoMessage = computed<string>(() => {
 	if (winningPlayerName.value === undefined) {
@@ -77,15 +50,11 @@ function closeSheet(): void {
 	points.value = undefined;
 }
 
-function hasPlayerWonTheRound(player: Player): boolean {
-	return currentRound.value?.winnerId === player.id;
-}
-
 /* -------------------------------------------------------------------------- */
 
-function onCollectPoints(playerId: Id): void {
-	selectedPlayer.value = playersStore.getPlayerById(playerId);
-	points.value = leftOverPointsPerPlayer[playerId];
+function onCollectPoints(player: Player): void {
+	selectedPlayer.value = player;
+	points.value = collectedPoints.value[player.id];
 	isSheetOpen.value = true;
 }
 
@@ -98,13 +67,13 @@ function onSavePoints(): void {
 	if (selectedPlayer.value === undefined) return;
 
 	// Set the left over points for the selected player.
-	leftOverPointsPerPlayer[selectedPlayer.value.id] = points.value;
+	setCollectedPoints(selectedPlayer.value.id, points.value);
 
 	closeSheet();
 }
 
 function onSubmit(): void {
-	emit('navigate-forward', leftOverPointsPerPlayer as LeftoverPoints);
+	emit('navigate-forward', collectedPoints.value as LeftoverPoints);
 }
 </script>
 
@@ -121,9 +90,9 @@ function onSubmit(): void {
 			>
 				<li>
 					<CollectPointsPlayerItem
-						:is-winner="hasPlayerWonTheRound(player)"
+						:is-winner="hasPlayerWonTheRound(player.id)"
 						:player="player"
-						:points="leftOverPointsPerPlayer[player.id]"
+						:points="collectedPoints[player.id]"
 						@collect="onCollectPoints"
 					/>
 				</li>
@@ -141,7 +110,7 @@ function onSubmit(): void {
 		<template #primary-action>
 			<button
 				type="button"
-				:disabled="!canContinue"
+				:disabled="!isComplete"
 				@click="onSubmit"
 			>
 				{{ $t('common.next') }}


### PR DESCRIPTION
The collect-points logic (player filtering, winner exclusion, completion
check) was embedded directly in CollectPointsScreen. This made the screen
hard to test in isolation and mixed orchestration concerns with UI state.

- Add useCollectPoints composable encapsulating collectedPoints state,
  isComplete, hasPlayerWonTheRound, winningPlayerName, and setCollectedPoints
- Initialise collectedPoints as a snapshot ref — safe because players
  cannot transition active→inactive during the round-end phase
- Guard setCollectedPoints against unknown player IDs with hasOwn
- Expose collectedPoints as readonly to prevent direct mutation
- Simplify CollectPointsScreen to delegate all business logic to the
  composable
- Widen CollectPointsPlayerItem @collect emit from Id to Player, removing
  the need for a store lookup in the screen
- Add full unit test coverage for the composable