### PR TITLE
fix(button): restore iOS touch active state via tap-highlight-color

### DIFF
--- a/src/assets/css/04-elements/_button.scss
+++ b/src/assets/css/04-elements/_button.scss
@@ -4,11 +4,16 @@
 
 /* ========================================================================== */
 
+$button_background-color: #DFCA8844;
+$button_background-color_active: color.adjust($button_background-color, $lightness: -60%);
+
 button {
-	-webkit-tap-highlight-color: transparent;
+	// Needed for iOS to have the active styling applied to the button when
+	// interacting with the button using touch.
+	-webkit-tap-highlight-color: #{$button_background-color_active};
 
 	align-items: center;
-	background-color: #DFCA8844;
+	background-color: $button_background-color;
 	border: none;
 	color: inherit;
 	cursor: pointer;
@@ -18,9 +23,6 @@ button {
 	justify-content: center;
 	padding: get-spacing(x-small) get-spacing();
 	touch-action: manipulation;
-	// Prevent text selection when the button is clicked, needed to have the
-	// active styling applied to the button on iOS when interacting with the
-	// button using touch.
 	user-select: none;
 
 	&:not(:disabled) {
@@ -32,7 +34,7 @@ button {
 		}
 
 		&:active {
-			background-color: color.adjust(#DFCA8844, $lightness: -60%);
+			background-color: $button_background-color_active;
 		}
 
 		@media(hover: hover) {


### PR DESCRIPTION
Setting -webkit-tap-highlight-color to transparent prevented iOS from showing the :active background when buttons were tapped with touch. Using the active background color as the highlight value makes touch interactions visually consistent with pointer interactions.

Also extracts the button background color into named SCSS variables to eliminate duplication between the default and active states.