### PR TITLE
fix(round-view): show aggregated score in turn header

### DIFF
--- a/src/views/RoundView.vue
+++ b/src/views/RoundView.vue
@@ -31,6 +31,7 @@ const { safeNavigateBack } = useNavigation();
 const { startNewRound } = useRoundsLogic();
 const { currentPlayerStats, hasCurrentRound } = storeToRefs(roundsStore);
 const { currentPhase, currentPlayer, finishRound, isFirstTurnOfRound, saveTurn, setStartingPlayer } = useRoundManager();
+const { totalScore } = useGameScores();
 
 const turnKey = ref<symbol>(Symbol(''));
 
@@ -39,7 +40,9 @@ const turnKey = ref<symbol>(Symbol(''));
 const subtitle = computed<string>(() => {
 	if (currentPlayerStats.value === undefined) return '';
 
-	return `${t('common.points', currentPlayerStats.value.score)} | ${t('common.tile', currentPlayerStats.value.tiles)}`;
+	const playerScore = totalScore.value[currentPlayerStats.value.id];
+
+	return `${t('common.points', playerScore)} | ${t('common.tile', currentPlayerStats.value.tiles)}`;
 });
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
The turn header subtitle used currentPlayerStats.score, which only reflects the current round. Past the first round this caused the header to display the in-progress round score alone rather than the player's cumulative total. Switching to totalScore from useGameScores correctly sums completed-round scores and the current round score.