### PR TITLE
fix(i18n): replace all hardcoded English strings with translation keys

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,9 @@
 		"pinia",
 		"triominos"
 	],
-	"files.eol": "\n"
+	"files.eol": "\n",
+	"i18n-ally.localesPaths": [
+		"src/i18n"
+	],
+	"i18n-ally.keystyle": "nested"
 }

--- a/src/components/CollectPointsPlayerItem.vue
+++ b/src/components/CollectPointsPlayerItem.vue
@@ -37,11 +37,11 @@ const { t } = useGlobalI18n();
 const hasPoints = computed<boolean>(() => props.points !== undefined);
 
 const message = computed<string>(() => {
-	if (props.isWinner) return t('collectPoints.winner');
+	if (props.isWinner) return t('collectPoints.winnerLabel');
 
 	return hasPoints.value
-		? t('collectPoints.pointsCollected', [props.points])
-		: t('collectPoints.pointsNotCollected');
+		? t('collectPoints.pointsCollectedStatus', props.points ?? 0)
+		: t('collectPoints.pointsPendingStatus');
 });
 
 /* -------------------------------------------------------------------------- */

--- a/src/components/ColorSchemeSelect.vue
+++ b/src/components/ColorSchemeSelect.vue
@@ -16,19 +16,19 @@ const { t } = useGlobalI18n();
 const options: ComputedRef<SelectOption[]> = computed(() => ([
 	{
 		id: 'auto',
-		label: t('settingsView.themeAuto'),
+		label: t('colorSchemeSelect.themeAuto'),
 		selected: model.value === undefined,
 		value: undefined
 	},
 	{
 		id: 'dark',
-		label: t('settingsView.themeDark'),
+		label: t('colorSchemeSelect.themeDark'),
 		selected: model.value === 'dark',
 		value: 'dark'
 	},
 	{
 		id: 'light',
-		label: t('settingsView.themeLight'),
+		label: t('colorSchemeSelect.themeLight'),
 		selected: model.value === 'light',
 		value: 'light'
 	}
@@ -41,6 +41,6 @@ const options: ComputedRef<SelectOption[]> = computed(() => ([
 		v-model="model"
 		:options="options"
 	>
-		{{ $t('settingsView.labelColorScheme') }}
+		{{ $t('colorSchemeSelect.title') }}
 	</SelectField>
 </template>

--- a/src/components/GameReset.vue
+++ b/src/components/GameReset.vue
@@ -30,14 +30,14 @@ function onUnderstoodToggled(value: boolean): void {
 			:is-selected="understood"
 			@toggle="onUnderstoodToggled"
 		>
-			I want to start a new game. When I do, all progress will be lost.
+			{{ $t('gameReset.warning') }}
 		</toggle-button>
 
 		<button
 			:disabled="!understood"
 			@click="onConfirmed"
 		>
-			Reset Game
+			{{ $t('gameReset.resetLabel') }}
 		</button>
 	</div>
 </template>

--- a/src/components/LanguageSelect.vue
+++ b/src/components/LanguageSelect.vue
@@ -1,27 +1,30 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import SelectField, { type SelectOption } from '@/components/SelectField.vue';
+import { useGlobalI18n } from '@/i18n';
 
 /* ========================================================================== */
 
 const model = defineModel<string | undefined>();
 
+const { t } = useGlobalI18n();
+
 const options = computed<SelectOption[]>(() => [
 	{
 		id: 'auto',
-		label: 'Auto',
+		label: t('languageSelect.languageAuto'),
 		selected: model.value === undefined,
 		value: undefined
 	},
 	{
 		id: 'en',
-		label: 'English',
+		label: t('languageSelect.languageEnglish'),
 		selected: model.value === 'en',
 		value: 'en'
 	},
 	{
 		id: 'nl',
-		label: 'Dutch',
+		label: t('languageSelect.languageDutch'),
 		selected: model.value === 'nl',
 		value: 'nl'
 	}
@@ -34,6 +37,6 @@ const options = computed<SelectOption[]>(() => [
 		v-model="model"
 		:options
 	>
-		{{ $t('settingsView.labelLanguage') }}
+		{{ $t('languageSelect.title') }}
 	</SelectField>
 </template>

--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -51,7 +51,7 @@ function onClose(): void {
 		class="trigger"
 		type="button"
 		:aria-expanded="isOpen"
-		aria-label="Open menu"
+		:aria-label="$t('mainMenu.openLabel')"
 		aria-haspopup="dialog"
 		@click="onOpen"
 	>
@@ -67,14 +67,14 @@ function onClose(): void {
 		<template #header>
 			<header class="sheet-header">
 				<h2 class="sheet-title">
-					Menu
+					{{ $t('mainMenu.title') }}
 				</h2>
 				<button
 					class="close-button"
 					type="button"
 					@click="onClose"
 				>
-					Close
+					{{ $t('common.close') }}
 				</button>
 			</header>
 		</template>
@@ -103,7 +103,7 @@ function onClose(): void {
 
 		<template #footer>
 			<small class="version-info">
-				v{{ appVersion }} / build {{ formattedBuildTimestamp }}
+				{{ $t('mainMenu.buildInfo', { version: appVersion, timestamp: formattedBuildTimestamp }) }}
 			</small>
 		</template>
 	</BottomSheet>

--- a/src/components/NumberPad.vue
+++ b/src/components/NumberPad.vue
@@ -95,9 +95,9 @@ function onKeyClicked(event: Event) {
 			<button
 				data-value="clear"
 				class="key is-function-key"
-				aria-label="clear input"
+				:aria-label="$t('numberPad.clearLabel')"
 			>
-				clr
+				{{ $t('numberPad.clearSymbol') }}
 			</button>
 		</template>
 
@@ -111,7 +111,7 @@ function onKeyClicked(event: Event) {
 		<button
 			data-value="backspace"
 			class="key is-function-key"
-			aria-label="delete last input"
+			:aria-label="$t('numberPad.deleteLabel')"
 		>
 			⌫
 		</button>

--- a/src/components/PlayerSelect.vue
+++ b/src/components/PlayerSelect.vue
@@ -18,7 +18,7 @@ const { t } = useGlobalI18n();
 /* -------------------------------------------------------------------------- */
 
 function onDelete() {
-	if (!confirm(t('messages.confirmRemovePlayer', [props.player.name]))) return;
+	if (!confirm(t('playerSelect.deleteConfirmation', { name: props.player.name }))) return;
 
 	emit('delete', props.player.id);
 }

--- a/src/components/PointsBottomSheet.vue
+++ b/src/components/PointsBottomSheet.vue
@@ -45,7 +45,7 @@ function onClose(): void {
 					type="button"
 					@click="onCancel"
 				>
-					Cancel
+					{{ $t('common.cancel') }}
 				</button>
 				<h2 class="title">
 					{{ playerName }}
@@ -55,7 +55,7 @@ function onClose(): void {
 					type="button"
 					@click="onClose"
 				>
-					Save
+					{{ $t('common.save') }}
 				</button>
 			</header>
 		</template>

--- a/src/components/ScoreLeaderboard.vue
+++ b/src/components/ScoreLeaderboard.vue
@@ -60,16 +60,16 @@ const leaderboardData = computed<LeaderboardEntry[]>(() => {
 					#
 				</th>
 				<th class="header-cell">
-					Name
+					{{ $t('scoreLeaderboard.nameLabel') }}
 				</th>
 				<th
 					v-if="showTiles"
 					class="header-cell"
 				>
-					Tiles
+					{{ $t('scoreLeaderboard.tilesLabel') }}
 				</th>
 				<th class="header-cell">
-					Score
+					{{ $t('scoreLeaderboard.scoreLabel') }}
 				</th>
 			</tr>
 		</thead>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,63 +1,88 @@
 {
 	"common": {
 		"back": "Back",
+		"cancel": "Cancel",
+		"close": "Close",
 		"decrease": "Decrease value",
 		"increase": "Increase value",
 		"next": "Next",
-		"player": "player",
 		"points": "{n} points | {n} point | {n} points",
 		"remove": "Remove",
+		"save": "Save",
 		"tile": "{n} tiles | {n} tile | {n} tiles"
 	},
-	"errorMessages": {
-		"hasCurrentRound": "Invalid action, there is already a current round",
-		"invalidLimit": "The limit is invalid",
-		"noActiveGame": "Invalid action, there is no active game",
-		"noCurrentRound": "Invalid action, there is no current round",
-		"noCurrentPlayer": "Invalid action, there is no current player",
-		"noWinner": "Invalid action, there is no winner"
+	"collectPoints": {
+		"pointsCollectedStatus": "@:common.points left",
+		"pointsPendingStatus": "Points not collected",
+		"roundBlocked": "The round is blocked. The player with the fewest points left in their hand will be the round winner.",
+		"roundWon": "{winner} has won the round. The total value of points left in each player's hand will be added to their score.",
+		"title": "Collect Points",
+		"winnerLabel": "Winner of the round"
 	},
-	"playerNames": {
-		"headingPlayers": "Players",
-		"infoMessage": "Please enter the names of the players. The game requires at least 2 players to play.",
-		"labelAdd": "Add",
-		"labelName": "New player name",
-		"namePlaceholder": "Enter player name",
-		"title": "Player Names"
-	},
-	"playerSelect": {
-		"infoMessage": "Each player gets <strong>{0} stones</strong>. Select the player who will start the round.",
-		"title": "Round {0} start"
-	},
-	"messages": {
-		"confirmRemovePlayer": "Are you sure you wish to remove player {0}?"
-	},
-	"validationMessages": {
-		"startingPlayerRequired": "You must select a player who will start the round.",
-		"tooFewPlayers": "The game requires at least {0} players to play.",
-		"tooManyPlayers": "The game requires a maximum of {0} players to play."
-	},
-	"gameLimit": {
-		"infoMessage": "Set the number of points needed to trigger the final round. The default is 400 points.",
-		"title": "Points Limit"
-	},
-	"roundView": {
-		"playerStats": "{0} @:common.points \u007C {1} @:common.tiles"
-	},
-	"settingsView": {
-		"labelColorScheme": "Color scheme",
-		"labelLanguage": "Language",
+	"colorSchemeSelect": {
 		"themeAuto": "Auto",
 		"themeDark": "Dark",
 		"themeLight": "Light",
-		"title": "Settings"
+		"title": "Color scheme"
 	},
-	"turnView": {
-		"isTripleStone": "The played stone is a triple, all sides have the same value (+{0} bonus points)."
+	"gameLimit": {
+		"description": "Set the number of points needed to trigger the final round. The default is 400 points.",
+		"title": "Points Limit"
 	},
-	"collectPoints": {
-		"pointsCollected": "{0} points left",
-		"pointsNotCollected": "Points not collected",
-		"winner": "Winner of the round"
+	"gamePlayers": {
+		"addLabel": "Add",
+		"description": "Please enter the names of the players. The game requires at least 2 players to play.",
+		"errorTooFewPlayers": "The game requires at least 2 players to play.",
+		"errorTooManyPlayers": "The game requires a maximum of 6 players to play.",
+		"nameLabel": "New player name",
+		"namePlaceholder": "Enter player name",
+		"playersLabel": "Players",
+		"title": "Player Names"
+	},
+	"gameReset": {
+		"resetLabel": "Reset Game",
+		"warning": "I want to start a new game. When I do, all progress will be lost."
+	},
+	"gameResult": {
+		"description": "The game is over. The winner is {winner} with the highest score.",
+		"newGameLabel": "New Game",
+		"title": "Game over"
+	},
+	"languageSelect": {
+		"languageAuto": "Auto",
+		"languageDutch": "Nederlands",
+		"languageEnglish": "English",
+		"title": "Language"
+	},
+	"mainMenu": {
+		"buildInfo": "v{version} / build {timestamp}",
+		"openLabel": "Open menu",
+		"title": "Menu"
+	},
+	"numberPad": {
+		"clearLabel": "Clear input",
+		"clearSymbol": "clr",
+		"deleteLabel": "Delete last input"
+	},
+	"playerSelect": {
+		"deleteConfirmation": "Are you sure you wish to remove player {name}?"
+	},
+	"scoreLeaderboard": {
+		"nameLabel": "Name",
+		"scoreLabel": "Score",
+		"tilesLabel": "Tiles"
+	},
+	"startingPlayer": {
+		"description": "Each player gets {stones}. Select the player who will start the round.",
+		"errorNoStartingPlayer": "You must select a player who will start the round.",
+		"title": "Round {ordinal} start"
+	},
+	"turn": {
+		"bonusBridgeLabel": "Bridge",
+		"bonusDoubleLabel": "Double",
+		"bonusHexagonLabel": "Hexagon",
+		"bonusScoringLabel": "Bonus scoring",
+		"tilesDrawnLabel": "Tiles drawn",
+		"tripleStone": "The played stone is a triple, all sides have the same value (+{bonus} bonus points)."
 	}
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -1,64 +1,88 @@
 {
 	"common": {
 		"back": "Terug",
-		"decrease": "Verminder",
-		"increase": "Verhoog",
+		"cancel": "Annuleren",
+		"close": "Sluiten",
+		"decrease": "Verlaag waarde",
+		"increase": "Verhoog waarde",
 		"next": "Volgende",
-		"player": "speler",
-		"points": "punten | punt | punten",
-		"remove": "Verwijder",
-		"tile": "stenen | steen | stenen"
-	},
-	"errorMessages": {
-		"hasCurrentRound": "Ongeldige actie, er is al een huidige ronde.",
-		"invalidLimit": "De limiet is ongeldig",
-		"noActiveGame": "Ongeldige actie, er is geen actief spel.",
-		"noCurrentRound": "Ongeldige actie, er is geen huidige ronde.",
-		"noCurrentPlayer": "Ongeldige actie, er is geen huidige speler.",
-		"noWinner": "Ongeldige actie, er is geen winnaar."
-	},
-	"playerNames": {
-		"headingPlayers": "Spelers",
-		"infoMessage": "Geef de namen op van de spelers. Er zijn minstens twee spelers nodig om te spelen.",
-		"labelAdd": "Toevoegen",
-		"labelName": "Nieuwe spelersnaam",
-		"namePlaceholder": "Geef naam speler op",
-		"title": "Spelersnamen"
-	},
-	"playerSelect": {
-		"infoMessage": "Elke speler krijgt <strong>{0} stenen</strong>. Kies de speler die de ronde zal beginnen.",
-		"title": "Start ronde {0}"
-	},
-	"messages": {
-		"confirmRemovePlayer": "Weet je zeker dat je speler {0} wilt verwijderen?"
-	},
-	"validationMessages": {
-		"startingPlayerRequired": "Je moet een speler selecteren die de ronde zal beginnen.",
-		"tooFewPlayers": "Het spel vereist minstens {0} spelers om te spelen.",
-		"tooManyPlayers": "Het spel vereist maximaal {0} spelers om te spelen."
-	},
-	"gameLimit": {
-		"infoMessage": "Stel het aantal punten in dat nodig is om de laatste ronde te starten. De standaard&shy;waarde is 400 punten.",
-		"title": "Puntendoel"
-	},
-	"roundView": {
-		"playerStats": "{0} @:common.points | {1} @:common.tiles"
-	},
-	"settingsView": {
-		"labelColorScheme": "Kleurthema",
-		"labelLanguage": "Taal",
-		"themeAuto": "Automatisch",
-		"themeDark": "Donker",
-		"themeLight": "Licht",
-		"title": "Instellingen"
-	},
-	"turnView": {
-		"isTripleStone": "De gespeelde steen is een triple, alle zijden hebben dezelfde waarde (+{0} bonus punten)."
+		"points": "{n} punten | {n} punt | {n} punten",
+		"remove": "Verwijderen",
+		"save": "Opslaan",
+		"tile": "{n} stenen | {n} steen | {n} stenen"
 	},
 	"collectPoints": {
-		"pointsCollected": "{0} punten over",
-		"pointsNotCollected": "Nog geen punten geteld",
-		"winner": "Winnaar van de ronde"
+		"pointsCollectedStatus": "@:common.points over",
+		"pointsPendingStatus": "Punten niet ingevoerd",
+		"roundBlocked": "De ronde is geblokkeerd. De speler met de minste punten in hand zal de ronde winnen.",
+		"roundWon": "{winner} heeft de ronde gewonnen. De totale waarde van de punten die overblijven in elke speler's hand wordt toegevoegd aan hun score.",
+		"title": "Punten verzamelen",
+		"winnerLabel": "Winnaar van de ronde"
+	},
+	"colorSchemeSelect": {
+		"themeAuto": "Auto",
+		"themeDark": "Donker",
+		"themeLight": "Licht",
+		"title": "Kleurenschema"
+	},
+	"gameLimit": {
+		"description": "Stel het aantal punten in dat nodig is om de laatste ronde te starten. De standaardwaarde is 400 punten.",
+		"title": "Puntenlimiet"
+	},
+	"gamePlayers": {
+		"addLabel": "Toevoegen",
+		"description": "Voer de namen van de spelers in. Het spel vereist minimaal 2 spelers.",
+		"errorTooFewPlayers": "Het spel vereist minimaal 2 spelers.",
+		"errorTooManyPlayers": "Het spel vereist maximaal 6 spelers.",
+		"nameLabel": "Naam nieuwe speler",
+		"namePlaceholder": "Voer spelersnaam in",
+		"playersLabel": "Spelers",
+		"title": "Spelersnamen"
+	},
+	"gameReset": {
+		"resetLabel": "Spel resetten",
+		"warning": "Ik wil een nieuw spel starten. Als ik dat doe, gaat alle voortgang verloren."
+	},
+	"gameResult": {
+		"description": "Het spel is afgelopen. De winnaar is {winner} met de hoogste score.",
+		"newGameLabel": "Nieuw spel",
+		"title": "Spel afgelopen"
+	},
+	"languageSelect": {
+		"languageAuto": "Auto",
+		"languageDutch": "Nederlands",
+		"languageEnglish": "English",
+		"title": "Taal"
+	},
+	"mainMenu": {
+		"buildInfo": "v{version} / build {timestamp}",
+		"openLabel": "Menu openen",
+		"title": "Menu"
+	},
+	"numberPad": {
+		"clearLabel": "Invoer wissen",
+		"clearSymbol": "wis",
+		"deleteLabel": "Laatste invoer verwijderen"
+	},
+	"playerSelect": {
+		"deleteConfirmation": "Weet je zeker dat je speler {name} wilt verwijderen?"
+	},
+	"scoreLeaderboard": {
+		"nameLabel": "Naam",
+		"scoreLabel": "Score",
+		"tilesLabel": "Stenen"
+	},
+	"startingPlayer": {
+		"description": "Elke speler krijgt {stones}. Kies de speler die de ronde zal beginnen.",
+		"errorNoStartingPlayer": "Je moet een speler selecteren die de ronde zal beginnen.",
+		"title": "Start ronde {ordinal}"
+	},
+	"turn": {
+		"bonusBridgeLabel": "Brug",
+		"bonusDoubleLabel": "Dubbel",
+		"bonusHexagonLabel": "Hexagoon",
+		"bonusScoringLabel": "Bonuspunten",
+		"tilesDrawnLabel": "Getrokken stenen",
+		"tripleStone": "De gespeelde steen is een drievoud, alle zijden hebben dezelfde waarde (+{bonus} bonuspunten)."
 	}
-
 }

--- a/src/screens/CollectPointsScreen.vue
+++ b/src/screens/CollectPointsScreen.vue
@@ -6,6 +6,7 @@ import CollectPointsPlayerItem from '@/components/CollectPointsPlayerItem.vue';
 import MessageBox from '@/components/MessageBox.vue';
 import PointsBottomSheet from '@/components/PointsBottomSheet.vue';
 import { useCollectPoints } from '@/composables/useCollectPoints';
+import { useGlobalI18n } from '@/i18n';
 
 /* ========================================================================== */
 
@@ -14,6 +15,8 @@ const emit = defineEmits<{
 }>();
 
 /* -------------------------------------------------------------------------- */
+
+const { t } = useGlobalI18n();
 
 const {
 	activePlayers,
@@ -33,10 +36,10 @@ const points = ref<number | undefined>(undefined);
 
 const infoMessage = computed<string>(() => {
 	if (winningPlayerName.value === undefined) {
-		return 'The round is blocked. The player with the fewest points left in their hand will be the round winner.';
+		return t('collectPoints.roundBlocked');
 	}
 
-	return `${winningPlayerName.value} has won the round. The total value of points left in each player's hand will be added to their score.`;
+	return t('collectPoints.roundWon', { winner: winningPlayerName.value });
 });
 
 /* -------------------------------------------------------------------------- */
@@ -78,7 +81,7 @@ function onSubmit(): void {
 </script>
 
 <template>
-	<AppScreen title="Collect Points">
+	<AppScreen :title="$t('collectPoints.title')">
 		<MessageBox>
 			{{ infoMessage }}
 		</MessageBox>

--- a/src/screens/GameLimitScreen.vue
+++ b/src/screens/GameLimitScreen.vue
@@ -48,7 +48,7 @@ function onNavigateForward() {
 <template>
 	<AppScreen :title="$t('gameLimit.title')">
 		<MessageBox>
-			<div v-html="$t('gameLimit.infoMessage')" />
+			<div v-html="$t('gameLimit.description')" />
 		</MessageBox>
 
 		<NumberDisplay :value="limit" />

--- a/src/screens/GamePlayersScreen.vue
+++ b/src/screens/GamePlayersScreen.vue
@@ -6,7 +6,6 @@ import AppScreen from '@/screens/AppScreen.vue';
 import MessageBox from '@/components/MessageBox.vue';
 import PlayerSelect from '@/components/PlayerSelect.vue';
 import TextInput from '@/components/TextInput.vue';
-import { useRules } from '@/composables/useRules';
 import { usePlayerManager } from '@/composables/usePlayerManager';
 
 // https://github.com/drag-drop-touch-js/dragdroptouch?tab=readme-ov-file
@@ -25,8 +24,6 @@ const emit = defineEmits<{
 /* -------------------------------------------------------------------------- */
 
 const { t } = useGlobalI18n();
-
-const { maximumNumberOfPlayers, minimumNumberOfPlayers } = useRules();
 
 const {
 	addNewPlayer,
@@ -56,12 +53,12 @@ function onAddPlayer(event: Event) {
 
 function onContinue() {
 	if (!hasReachedMinimum.value) {
-		validationError.value = t('validationMessages.tooFewPlayers', [minimumNumberOfPlayers]);
+		validationError.value = t('gamePlayers.errorTooFewPlayers');
 		return;
 	}
 
 	if (hasExceededMaximum.value) {
-		validationError.value = t('validationMessages.tooManyPlayers', [maximumNumberOfPlayers]);
+		validationError.value = t('gamePlayers.errorTooManyPlayers');
 		return;
 	}
 
@@ -76,9 +73,9 @@ function onDeletePlayer(id: Id) {
 </script>
 
 <template>
-	<AppScreen :title="$t('playerNames.title')">
+	<AppScreen :title="$t('gamePlayers.title')">
 		<MessageBox>
-			{{ $t('playerNames.infoMessage') }}
+			{{ $t('gamePlayers.description') }}
 		</MessageBox>
 
 		<form
@@ -92,15 +89,15 @@ function onDeletePlayer(id: Id) {
 				v-model="name"
 				:disabled="hasReachedMaximum"
 				:hide-label="true"
-				:placeholder="$t('playerNames.namePlaceholder')"
+				:placeholder="$t('gamePlayers.namePlaceholder')"
 			>
-				{{ $t('playerNames.labelName') }}
+				{{ $t('gamePlayers.nameLabel') }}
 				<template #after-input>
 					<button
 						type="submit"
 						:disabled="hasReachedMaximum"
 					>
-						{{ $t('playerNames.labelAdd') }}
+						{{ $t('gamePlayers.addLabel') }}
 					</button>
 				</template>
 			</TextInput>
@@ -108,7 +105,7 @@ function onDeletePlayer(id: Id) {
 
 		<section>
 			<h2 v-if="hasPlayers">
-				{{ $t('playerNames.headingPlayers') }}
+				{{ $t('gamePlayers.playersLabel') }}
 			</h2>
 			<ol>
 				<li

--- a/src/screens/GameResultScreen.vue
+++ b/src/screens/GameResultScreen.vue
@@ -24,9 +24,9 @@ function onContinue() {
 </script>
 
 <template>
-	<AppScreen title="Game over">
+	<AppScreen :title="$t('gameResult.title')">
 		<MessageBox>
-			The game is over. The winner is {{ winner?.name }} with the highest score.
+			{{ $t('gameResult.description', { winner: winner?.name }) }}
 		</MessageBox>
 
 		<ScoreLeaderboard />
@@ -35,7 +35,7 @@ function onContinue() {
 			<button
 				@click="onContinue"
 			>
-				New Game
+				{{ $t('gameResult.newGameLabel') }}
 			</button>
 		</template>
 	</AppScreen>

--- a/src/screens/StartingPlayerScreen.vue
+++ b/src/screens/StartingPlayerScreen.vue
@@ -59,9 +59,16 @@ function onNavigateForward(): void {
 </script>
 
 <template>
-	<AppScreen :title="$t('playerSelect.title', [currentRoundOrdinal ?? 0])">
+	<AppScreen :title="$t('startingPlayer.title', { ordinal: currentRoundOrdinal ?? 0 })">
 		<MessageBox>
-			<div v-html="$t('playerSelect.infoMessage', [stonesPerPlayer])" />
+			<i18n-t
+				keypath="startingPlayer.description"
+				tag="div"
+			>
+				<template #stones>
+					<strong>{{ $t('common.tile', stonesPerPlayer) }}</strong>
+				</template>
+			</i18n-t>
 		</MessageBox>
 
 		<ToggleButtonGroup
@@ -82,7 +89,7 @@ function onNavigateForward(): void {
 			v-if="showValidationMessage"
 			type="warning"
 		>
-			<div v-html="$t('validationMessages.startingPlayerRequired')" />
+			<div v-html="$t('startingPlayer.errorNoStartingPlayer')" />
 		</MessageBox>
 
 		<template #primary-action>

--- a/src/screens/TurnScreen.vue
+++ b/src/screens/TurnScreen.vue
@@ -120,12 +120,14 @@ function onToggleIsTripleStone(value: boolean) {
 				:is-selected="isTripleStone"
 				@toggle="onToggleIsTripleStone"
 			>
-				{{ $t('turnView.isTripleStone', [openingTurnBonus]) }}
+				{{ $t('turn.tripleStone', { bonus: openingTurnBonus }) }}
 			</ToggleButton>
 		</template>
 		<template v-else>
 			<div class="tiles-drawn-wrapper">
-				<label for="tiles-drawn">Tiles drawn</label>
+				<label for="tiles-drawn">
+					{{ $t('turn.tilesDrawnLabel') }}
+				</label>
 				<number-spinner
 					v-model="tilesDrawn"
 					:max="3"
@@ -133,7 +135,9 @@ function onToggleIsTripleStone(value: boolean) {
 			</div>
 
 			<div>
-				<label>Bonus scoring</label>
+				<label>
+					{{ $t('turn.bonusScoringLabel') }}
+				</label>
 
 				<ToggleButtonGroup
 					orientation="horizontal"
@@ -142,23 +146,23 @@ function onToggleIsTripleStone(value: boolean) {
 					<ShapeToggleButton :id="'bridge' satisfies BonusShape">
 						<img
 							src="@/assets/images/bridge.png"
-							alt="Bridge"
+							:alt="$t('turn.bonusBridgeLabel')"
 						>
-						bridge
+						{{ $t('turn.bonusBridgeLabel') }}
 					</ShapeToggleButton>
 					<ShapeToggleButton :id="'double' satisfies BonusShape">
 						<img
 							src="@/assets/images/double-sided.png"
-							alt="Double"
+							:alt="$t('turn.bonusDoubleLabel')"
 						>
-						double
+						{{ $t('turn.bonusDoubleLabel') }}
 					</ShapeToggleButton>
 					<ShapeToggleButton :id="'hexagon' satisfies BonusShape">
 						<img
 							src="@/assets/images/hexagon.png"
-							alt="Hexagon"
+							:alt="$t('turn.bonusHexagonLabel')"
 						>
-						hexagon
+						{{ $t('turn.bonusHexagonLabel') }}
 					</ShapeToggleButton>
 				</ToggleButtonGroup>
 			</div>


### PR DESCRIPTION
All user-facing strings were hardcoded in English directly inside
components and screens. This made the app functionally English-only
even though vue-i18n was already in place.

This PR completes the i18n coverage by moving every remaining string
into the locale files and calling `t()` in the templates and scripts.

Changes:
- Add translation keys to `en.json` and `nl.json` for all previously
  hardcoded strings across components and screens
- Update all affected components and screens to use `useGlobalI18n()`
  and the `t()` helper in place of raw string literals
- Configure the i18n Ally VSCode extension for the nested locale
  file structure used in this project