### PR TITLE
refactor(screens): replace unnecessary v-html with text interpolation

### DIFF
--- a/src/screens/GameLimitScreen.vue
+++ b/src/screens/GameLimitScreen.vue
@@ -48,7 +48,7 @@ function onNavigateForward() {
 <template>
 	<AppScreen :title="$t('gameLimit.title')">
 		<MessageBox>
-			<div v-html="$t('gameLimit.description')" />
+			{{ $t('gameLimit.description') }}
 		</MessageBox>
 
 		<NumberDisplay :value="limit" />

--- a/src/screens/StartingPlayerScreen.vue
+++ b/src/screens/StartingPlayerScreen.vue
@@ -89,7 +89,7 @@ function onNavigateForward(): void {
 			v-if="showValidationMessage"
 			type="warning"
 		>
-			<div v-html="$t('startingPlayer.errorNoStartingPlayer')" />
+			{{ $t('startingPlayer.errorNoStartingPlayer') }}
 		</MessageBox>
 
 		<template #primary-action>


### PR DESCRIPTION
Two screen components used `v-html` to render i18n strings that contain
no HTML markup. This was flagged as a latent XSS surface (#26) because
`v-html` bypasses Vue's built-in escaping.

Both strings are now rendered with standard `{{ }}` interpolation, which
is correct and sufficient since neither translation value contains HTML.

The `v-html` usage for `startingPlayer.description` (which did
interpolate user-provided data) was already resolved separately via
`<i18n-t>`. This PR handles the remaining two static-string cases.