### PR TITLE
refactor(composables): extract requireCurrentRound guard helper

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -123,7 +123,9 @@ export default [
 			'@stylistic/member-delimiter-style': ['error'],
 			'@stylistic/no-tabs': ['error', { allowIndentationTabs: true }],
 			'@stylistic/object-curly-spacing': ['error', 'always'],
-			'@stylistic/operator-linebreak': ['error', 'after', { overrides: { '?': 'before', ':': 'before' } }],
+			'@stylistic/operator-linebreak': ['error', 'after', {
+				overrides: { '?': 'before', ':': 'before', '|': 'before' }
+			}],
 			'@stylistic/quote-props': ['error', 'as-needed'],
 			'@stylistic/quotes': ['error', 'single'],
 			'@stylistic/semi': ['error', 'always'],

--- a/src/composables/useRoundManager.ts
+++ b/src/composables/useRoundManager.ts
@@ -12,6 +12,12 @@ import { useRules } from '@/composables/useRules';
 
 /* ========================================================================== */
 
+type RequireCurrentRoundResult =
+	| { success: true; round: CurrentRound }
+	| { success: false; message: string };
+
+/* ========================================================================== */
+
 export function useRoundManager() {
 	const playersStore = usePlayersStore();
 	const roundsLogic = useRoundsLogic();
@@ -60,15 +66,26 @@ export function useRoundManager() {
 
 	/* ---------------------------------------------------------------------- */
 
+	function requireCurrentRound(): RequireCurrentRoundResult {
+		const round = currentRound.value;
+
+		return round === undefined
+			? { success: false, message: t('error.noCurrentRound') }
+			: { success: true, round };
+	}
+
+	/* ---------------------------------------------------------------------- */
+
 	/**
 	 * Determines the next player in the round and updates the current player
 	 * ID for the current round.
 	 */
 	function advanceToNextPlayer(): void {
-		if (currentRound.value === undefined) return;
+		const result = requireCurrentRound();
+		if (!result.success) return;
 		if (currentPlayerId.value === undefined) return;
 
-		const playerIds = currentRound.value.playerStats.map(player => player.id);
+		const playerIds = result.round.playerStats.map(player => player.id);
 		const currentPlayerIndex = playerIds.indexOf(currentPlayerId.value);
 
 		if (currentPlayerIndex === -1) return;
@@ -99,14 +116,10 @@ export function useRoundManager() {
 	/* ---------------------------------------------------------------------- */
 
 	function finishRound(leftOverPoints: Scores): Feedback {
-		const round = currentRound.value;
-		if (round === undefined) {
-			return {
-				message: t('error.noCurrentRound'),
-				success: false
-			};
-		}
+		const result = requireCurrentRound();
+		if (!result.success) return result;
 
+		const round = result.round;
 		const isBlocked = (round.isBlocked ?? false);
 
 		if (!isBlocked && round.winnerId === undefined) {
@@ -175,12 +188,8 @@ export function useRoundManager() {
 	 * @returns A feedback object indicating success or failure.
 	 */
 	function setStartingPlayer(playerId: Id): Feedback {
-		if (!currentRound.value) {
-			return {
-				message: t('error.noCurrentRound'),
-				success: false
-			};
-		}
+		const result = requireCurrentRound();
+		if (!result.success) return result;
 
 		roundsStore.updateCurrentRound({
 			currentPlayerId: playerId,

--- a/src/composables/useRoundsLogic.ts
+++ b/src/composables/useRoundsLogic.ts
@@ -13,6 +13,12 @@ import { useRules } from './useRules';
 
 /* ========================================================================== */
 
+type RequireCurrentRoundResult =
+	| { success: true; round: CurrentRound }
+	| { success: false; message: string };
+
+/* ========================================================================== */
+
 export function useRoundsLogic() {
 	const gameStore = useGameStore();
 	const playersStore = usePlayersStore();
@@ -25,6 +31,16 @@ export function useRoundsLogic() {
 	const { determineStonesPerPlayer } = useRules();
 	const { currentPlayerId, currentRound, currentRoundOrdinal, hasCurrentRound } = storeToRefs(roundsStore);
 	const { t } = useGlobalI18n();
+
+	/* ---------------------------------------------------------------------- */
+
+	function requireCurrentRound(): RequireCurrentRoundResult {
+		const round = currentRound.value;
+
+		return round === undefined
+			? { success: false, message: t('error.noCurrentRound') }
+			: { success: true, round };
+	}
 
 	/* ---------------------------------------------------------------------- */
 
@@ -61,12 +77,8 @@ export function useRoundsLogic() {
 	 *          no current round to finish.
 	 */
 	function finishCurrentRound(scores: Scores): Feedback {
-		if (!hasCurrentRound.value) {
-			return {
-				success: false,
-				message: t('error.noCurrentRound')
-			};
-		}
+		const result = requireCurrentRound();
+		if (!result.success) return result;
 
 		roundsStore.completeCurrentRound(scores);
 
@@ -79,12 +91,9 @@ export function useRoundsLogic() {
 	 *        of tiles drawn, whether a triple was played, and the score.
 	 */
 	function saveTurn(turnInput: ScoredTurnInput): Feedback {
-		if (currentRound.value === undefined) {
-			return {
-				message: t('error.noCurrentRound'),
-				success: false
-			};
-		};
+		const result = requireCurrentRound();
+		if (!result.success) return result;
+
 		if (currentPlayerId.value === undefined) {
 			return {
 				message: t('error.noCurrentPlayer'),

--- a/src/types/Turn.d.ts
+++ b/src/types/Turn.d.ts
@@ -102,10 +102,10 @@ declare global {
 	type Turn = SkippedTurn | PlayedTurn;
 
 	type ScoredTurnInput =
-		Omit<SkippedTurn, 'id' | 'playerId' | 'roundId'> |
-		Omit<PlayedTurn, 'id' | 'playerId' | 'roundId'>;
+		| Omit<SkippedTurn, 'id' | 'playerId' | 'roundId'>
+		| Omit<PlayedTurn, 'id' | 'playerId' | 'roundId'>;
 
 	type TurnInput =
-		Omit<SkippedTurn, 'id' | 'playerId' | 'roundId' | 'score'> |
-		Omit<PlayedTurn, 'id' | 'playerId' | 'roundId' | 'score'>;
+		| Omit<SkippedTurn, 'id' | 'playerId' | 'roundId' | 'score'>
+		| Omit<PlayedTurn, 'id' | 'playerId' | 'roundId' | 'score'>;
 }


### PR DESCRIPTION
Multiple functions repeated the same inline null-check and error object construction for the absent-round case. Extracting requireCurrentRound() centralises the check and returns a discriminated union, letting call sites use a single early-return instead of duplicated guard blocks.

Also adds '|' to the ESLint operator-linebreak overrides to match the line-break style used in the new union type definitions.

Closes #21 