### PR TITLE
refactor: enforce no-shadow rule and rename shadowing parameters

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -139,5 +139,14 @@ export default [
 			'vue/html-indent': ['error', 'tab'],
 			'vue/v-on-event-hyphenation': ['error']
 		}
+	},
+
+	// General TypeScript source rules.
+	{
+		name: 'app/source',
+		files: ['src/**/*.{ts,mts,vue}'],
+		rules: {
+			'@typescript-eslint/no-shadow': 'error'
+		}
 	}
 ];

--- a/src/components/NumberSpinner.vue
+++ b/src/components/NumberSpinner.vue
@@ -32,13 +32,13 @@ watch(model, newValue => {
 
 /* -------------------------------------------------------------------------- */
 
-function clampValue(value: number | undefined): number {
-	if (value === undefined) return props.min;
+function clampValue(inputValue: number | undefined): number {
+	if (inputValue === undefined) return props.min;
 
-	if (value < props.min) return props.min;
-	if (value > props.max) return props.max;
+	if (inputValue < props.min) return props.min;
+	if (inputValue > props.max) return props.max;
 
-	return value;
+	return inputValue;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/composables/useGameScores.ts
+++ b/src/composables/useGameScores.ts
@@ -85,11 +85,11 @@ export function useGameScores() {
 	const winningPlayerId = computed<Id | undefined>(() => {
 		if (!hasReachedPointsLimit.value) return undefined;
 
-		const [winner, ...players] = Object.entries(totalScore.value) as [Id, number][];
+		const [initialWinner, ...players] = Object.entries(totalScore.value) as [Id, number][];
 
 		return players.reduce((winner, player) =>
 			player[1] > winner[1] ? player : winner,
-		winner)[0];
+		initialWinner)[0];
 	});
 
 	const winner = computed<Player | undefined>(() => {

--- a/src/composables/useRoundManager.ts
+++ b/src/composables/useRoundManager.ts
@@ -133,11 +133,11 @@ export function useRoundManager() {
 			? determineRoundWinnerAndPoints(leftOverPoints, true)
 			: determineRoundWinnerAndPoints(leftOverPoints, false, round.winnerId!);
 
-		const scores = round.playerStats.reduce((result, player) => {
-			result[player.id] = player.score;
-			if (player.id === pointsForWinner.winnerId) result[player.id] += pointsForWinner.points;
+		const scores = round.playerStats.reduce((accumulator, player) => {
+			accumulator[player.id] = player.score;
+			if (player.id === pointsForWinner.winnerId) accumulator[player.id] += pointsForWinner.points;
 
-			return result;
+			return accumulator;
 		}, {} as Scores);
 
 		// Update the winner of the current round.

--- a/src/stores/players.ts
+++ b/src/stores/players.ts
@@ -31,7 +31,7 @@ export const usePlayersStore = defineStore('players', () => {
 	 *          not found.
 	 */
 	function getPlayerById(id: Id): Player | undefined {
-		const player = players.value.find(player => player.id === id);
+		const player = players.value.find(existingPlayer => existingPlayer.id === id);
 
 		return player === undefined ? undefined : { ...player };
 	}


### PR DESCRIPTION
Callback parameters in several files silently shadowed outer-scope bindings (value, player, winner, result), making code harder to reason about. Adding @typescript-eslint/no-shadow to the ESLint config makes these visible at lint time. Affected parameters are renamed to be unambiguous: inputValue, existingPlayer, initialWinner, accumulator.