### PR TITLE
fix(scoring): detect game end when finishing winning round

### DIFF
--- a/src/composables/useGameScores.test.ts
+++ b/src/composables/useGameScores.test.ts
@@ -1,4 +1,3 @@
-import { nextTick } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -148,6 +147,26 @@ describe('useGameScores', () => {
 
 			expect(hasReachedPointsLimit.value).toBe(true);
 		});
+
+		it('should return true synchronously after a current round is completed past the limit', () => {
+			const playerId = generateId();
+			const roundsStore = useRoundsStore();
+
+			createGame(100);
+			createRounds([{
+				id: generateId(),
+				isCurrentRound: true,
+				phase: 'round-end',
+				playerStats: [{ id: playerId, score: 110, tiles: 0 }],
+				winnerId: playerId
+			}]);
+
+			const { hasReachedPointsLimit } = useGameScores();
+
+			roundsStore.completeCurrentRound({ [playerId]: 110 });
+
+			expect(hasReachedPointsLimit.value).toBe(true);
+		});
 	});
 
 	/* ---------------------------------------------------------------------- */
@@ -259,7 +278,7 @@ describe('useGameScores', () => {
 			});
 		});
 
-		it('should include a round completed after composable creation', async () => {
+		it('should include a round completed after composable creation', () => {
 			const playerId = generateId();
 			createRounds([{
 				id: generateId(),
@@ -270,7 +289,6 @@ describe('useGameScores', () => {
 
 			const { totalScore } = useGameScores();
 
-			// Simulate a round being completed during active gameplay
 			createRounds([
 				{
 					id: generateId(),
@@ -285,8 +303,6 @@ describe('useGameScores', () => {
 					winnerId: playerId
 				}
 			]);
-
-			await nextTick();
 
 			expect(totalScore.value).toEqual({ [playerId]: 60 });
 		});

--- a/src/composables/useGameScores.ts
+++ b/src/composables/useGameScores.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch } from 'vue';
+import { computed } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { useGameStore } from '@/stores/game';
@@ -17,26 +17,6 @@ export function useGameScores() {
 
 	/* -- Score Aggregation ------------------------------------------------- */
 
-	function addFinishedRoundScore(
-		aggregatedScore: ScorePerPlayer,
-		round: CompletedRound
-	): ScorePerPlayer {
-		const updatedScores = { ...aggregatedScore };
-
-		(Object.keys(round.scores) as Id[]).forEach(playerId => {
-			updatedScores[playerId] = (updatedScores[playerId] ?? 0) + round.scores[playerId];
-		});
-
-		return updatedScores;
-	}
-
-	function initializeFinishedRoundsScore(): ScorePerPlayer {
-		return completedRounds.value.reduce(
-			(acc, round) => addFinishedRoundScore(acc, round),
-			{} as ScorePerPlayer
-		);
-	}
-
 	const currentRoundScore = computed<ScorePerPlayer>(() => {
 		if (currentRound.value === undefined) return {};
 
@@ -46,7 +26,15 @@ export function useGameScores() {
 		}, {} as ScorePerPlayer);
 	});
 
-	const finishedRoundsScore = ref<ScorePerPlayer>(initializeFinishedRoundsScore());
+	const finishedRoundsScore = computed<ScorePerPlayer>(() => {
+		return completedRounds.value.reduce((acc, round) => {
+			(Object.keys(round.scores) as Id[]).forEach(playerId => {
+				acc[playerId] = (acc[playerId] ?? 0) + round.scores[playerId];
+			});
+
+			return acc;
+		}, {} as ScorePerPlayer);
+	});
 
 	const totalScore = computed<ScorePerPlayer>(() => {
 		const keys = new Set<Id>([
@@ -62,17 +50,6 @@ export function useGameScores() {
 
 		return result;
 	});
-
-	watch(completedRounds, (rounds, oldRounds) => {
-		// completedRounds changes frequently but actual updates are rare. Only
-		// recalculate the scores when the number of completed rounds changes.
-		if (rounds.length === oldRounds.length) return;
-
-		finishedRoundsScore.value = addFinishedRoundScore(
-			finishedRoundsScore.value,
-			rounds.at(-1) as CompletedRound
-		);
-	}, { immediate: false });
 
 	/* -- Game State -------------------------------------------------------- */
 

--- a/src/test-factories/player.ts
+++ b/src/test-factories/player.ts
@@ -6,7 +6,7 @@ import { assertActivePinia } from './assertActivePinia';
 
 /* ========================================================================== */
 
-function createPlayer(id: Id, name: string): Player {
+function createPlayer(name: string, id: Id = generateId()): Player {
 	return {
 		active: true,
 		id,

--- a/src/test-factories/round.ts
+++ b/src/test-factories/round.ts
@@ -1,6 +1,6 @@
 import { useRules } from '@/composables/useRules';
 
-import { useRoundsStore } from '@/stores/rounds';
+import { useRoundsStore, type Scores } from '@/stores/rounds';
 
 import { generateId } from '@/utilities/id';
 
@@ -8,15 +8,25 @@ import { assertActivePinia } from './assertActivePinia';
 
 /* ========================================================================== */
 
-function createCurrentRound(playerIds: Id[], phase: RoundPhase = 'turns'): CurrentRound {
+function createCurrentRound(playerIds: Id[], phase: RoundPhase = 'turns', winnerId?: Id): CurrentRound {
 	const tileCount = useRules().determineStonesPerPlayer(playerIds.length);
 
 	return {
 		id: generateId(),
 		isCurrentRound: true,
 		phase,
-		playerStats: playerIds.map(id => ({ id, score: 0, tiles: tileCount }))
+		playerStats: playerIds.map(id => ({ id, score: 0, tiles: tileCount })),
+		winnerId
 	} satisfies CurrentRound;
+}
+
+function createCompletedRound(winnerId: Id, scores: Scores): CompletedRound {
+	return {
+		id: generateId(),
+		isCurrentRound: false,
+		scores,
+		winnerId
+	} satisfies CompletedRound;
 }
 
 function addNewCurrentRoundToStore(playerIds: Id[]): Round {
@@ -32,5 +42,6 @@ function addNewCurrentRoundToStore(playerIds: Id[]): Round {
 
 export {
 	addNewCurrentRoundToStore,
+	createCompletedRound,
 	createCurrentRound
 };

--- a/src/views/RoundView.test.ts
+++ b/src/views/RoundView.test.ts
@@ -1,0 +1,116 @@
+import { shallowMount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { routeName } from '@/router/routerName';
+
+import { useGameStore } from '@/stores/game';
+import { usePlayersStore } from '@/stores/players';
+import { useRoundsStore } from '@/stores/rounds';
+
+import RoundView from './RoundView.vue';
+import CollectPointsScreen from '@/screens/CollectPointsScreen.vue';
+import { createPlayer, createCompletedRound, createCurrentRound } from '@/test-factories';
+
+/* ========================================================================== */
+
+vi.mock('@/i18n');
+
+/* -- Vue Router Mocks ------------------------------------------------------ */
+
+const replaceMock = vi.fn();
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({
+		back: vi.fn(),
+		replace: replaceMock
+	})
+}));
+
+/* -------------------------------------------------------------------------- */
+
+function setupGameAtRoundEnd(options: {
+	completedRounds?: CompletedRound[];
+	pointsLimit: number;
+	players: Player[];
+	playerStats: PlayerStats[];
+	winnerId: Id;
+}): void {
+	const gameStore = useGameStore();
+	const playersStore = usePlayersStore();
+	const roundsStore = useRoundsStore();
+
+	gameStore.createNewGame(options.pointsLimit);
+
+	const playerIds = options.players.map(player => {
+		playersStore.addPlayer(player);
+
+		return player.id;
+	});
+
+	if (options.completedRounds) {
+		roundsStore.$patch({ rounds: [...options.completedRounds] });
+	}
+
+	roundsStore.addRound(createCurrentRound(playerIds, 'round-end', options.winnerId));
+}
+
+/* -------------------------------------------------------------------------- */
+
+beforeEach(() => {
+	setActivePinia(createPinia());
+	replaceMock.mockClear();
+});
+
+/* -------------------------------------------------------------------------- */
+
+describe('RoundView', () => {
+	it('should navigate to the game result when the points limit is reached after finishing a round', async () => {
+		const winner: Player = createPlayer('Alice');
+		const loser: Player = createPlayer('Bob');
+
+		setupGameAtRoundEnd({
+			completedRounds: [
+				createCompletedRound(winner.id, { [winner.id]: 70, [loser.id]: 30 })
+			],
+			pointsLimit: 100,
+			players: [winner, loser],
+			playerStats: [
+				{ id: winner.id, score: 20, tiles: 0 },
+				{ id: loser.id, score: 5, tiles: 3 }
+			],
+			winnerId: winner.id
+		});
+
+		const wrapper = shallowMount(RoundView);
+		const collectScreen = wrapper.findComponent(CollectPointsScreen);
+
+		collectScreen.vm.$emit('navigate-forward', { [loser.id]: 15 });
+		await wrapper.vm.$nextTick();
+
+		expect(replaceMock).toHaveBeenCalledWith({ name: routeName.gameResult });
+	});
+
+	it('should not navigate to game result when the points limit has not been reached', async () => {
+		const winner: Player = createPlayer('Alice');
+		const loser: Player = createPlayer('Bob');
+
+		setupGameAtRoundEnd({
+			pointsLimit: 400,
+			players: [winner, loser],
+			playerStats: [
+				{ id: winner.id, score: 30, tiles: 0 },
+				{ id: loser.id, score: 10, tiles: 3 }
+			],
+			winnerId: winner.id
+		});
+
+		const wrapper = shallowMount(RoundView);
+		const collectScreen = wrapper.findComponent(CollectPointsScreen);
+
+		collectScreen.vm.$emit('navigate-forward', { [loser.id]: 5 });
+		await wrapper.vm.$nextTick();
+
+		expect(replaceMock).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
finishedRoundsScore used ref+watch on completedRounds length, so
hasReachedPointsLimit could stay false right after finishRound() when
the winning round completed the points limit. Deriving finished round
scores from computed completedRounds keeps totalScore synchronous.

- RoundView tests assert navigation to game-result when the limit is met.
- useGameScores tests assert limit detection after completeCurrentRound.
- Test factories: createCompletedRound, optional winnerId on createCurrentRound.