### PR TITLE
fix(useCollectPoints): replace unsafe cast with type guard for leftover points

### DIFF
--- a/src/composables/useCollectPoints.test.ts
+++ b/src/composables/useCollectPoints.test.ts
@@ -6,7 +6,7 @@ import { generateId } from '@/utilities/id';
 import { usePlayersStore } from '@/stores/players';
 import { useRoundsStore } from '@/stores/rounds';
 
-import { useCollectPoints } from './useCollectPoints';
+import { useCollectPoints, type CollectedPoints } from './useCollectPoints';
 
 /* ========================================================================== */
 
@@ -39,6 +39,40 @@ beforeEach(() => setActivePinia(createPinia()));
 /* -------------------------------------------------------------------------- */
 
 describe('useCollectPoints', () => {
+	describe('areCollectedPointsComplete', () => {
+		it('should return false when the collected points are an empty object', () => {
+			const input: CollectedPoints = {};
+
+			const { areCollectedPointsComplete } = useCollectPoints();
+
+			expect(areCollectedPointsComplete(input)).toBe(false);
+		});
+
+		it('should return false as long as a player has not collected points', () => {
+			const input: CollectedPoints = {
+				[generateId()]: 0,
+				[generateId()]: undefined,
+				[generateId()]: 12
+			};
+
+			const { areCollectedPointsComplete } = useCollectPoints();
+
+			expect(areCollectedPointsComplete(input)).toBe(false);
+		});
+
+		it('should return true when all players have collected points', () => {
+			const input: CollectedPoints = {
+				[generateId()]: 0,
+				[generateId()]: 12,
+				[generateId()]: 24
+			};
+
+			const { areCollectedPointsComplete } = useCollectPoints();
+
+			expect(areCollectedPointsComplete(input)).toBe(true);
+		});
+	});
+
 	describe('collectedPoints', () => {
 		it('should be an empty object when there are no active players', () => {
 			const { collectedPoints } = useCollectPoints();

--- a/src/composables/useCollectPoints.ts
+++ b/src/composables/useCollectPoints.ts
@@ -6,7 +6,7 @@ import { useRoundsStore } from '@/stores/rounds';
 
 /* ========================================================================== */
 
-type CollectedPoints = {
+export type CollectedPoints = {
 	[id: Id]: number | undefined;
 };
 
@@ -37,9 +37,7 @@ export function useCollectPoints() {
 		}, {})
 	);
 
-	const isComplete = computed<boolean>(() => {
-		return Object.values(collectedPoints.value).every(points => points !== undefined);
-	});
+	const isComplete = computed<boolean>(() => areCollectedPointsComplete(collectedPoints.value));
 
 	const winningPlayerName = computed<string | undefined>(() => {
 		if (currentRound.value?.winnerId === undefined) return undefined;
@@ -50,6 +48,14 @@ export function useCollectPoints() {
 	});
 
 	/* ---------------------------------------------------------------------- */
+
+	function areCollectedPointsComplete(points: CollectedPoints): points is LeftoverPoints {
+		const values = Object.values(points);
+
+		return (values.length === 0)
+			? false
+			: values.every(p => p !== undefined);
+	}
 
 	function hasPlayerWonTheRound(playerId: Id): boolean {
 		return currentRound.value?.winnerId === playerId;
@@ -65,6 +71,8 @@ export function useCollectPoints() {
 
 	return {
 		activePlayers,
+
+		areCollectedPointsComplete,
 
 		/**
 		 * The collected points for each player in the current round. The value

--- a/src/composables/useRoundManager.test.ts
+++ b/src/composables/useRoundManager.test.ts
@@ -1,7 +1,14 @@
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { addNewCurrentRoundToStore, addNewPlayersToStore, addNewTurnsToStore, createPlayedTurn, createPlayer, createSkippedTurn } from '@/test-factories';
+import {
+	addNewCurrentRoundToStore,
+	addNewPlayersToStore,
+	addNewTurnsToStore,
+	createPlayedTurn,
+	createPlayer,
+	createSkippedTurn
+} from '@/test-factories';
 
 import { generateId } from '@/utilities/id';
 

--- a/src/composables/useRoundsLogic.test.ts
+++ b/src/composables/useRoundsLogic.test.ts
@@ -4,7 +4,14 @@ import { useRoundsLogic } from './useRoundsLogic';
 import { generateId } from '@/utilities/id';
 import { createPinia, setActivePinia } from 'pinia';
 import { useTurnsStore } from '@/stores/turns';
-import { addNewCurrentRoundToStore, addNewGameToStore, addNewTurnsToStore, createPlayedTurn, createPlayer, createSkippedTurn } from '@/test-factories';
+import {
+	addNewCurrentRoundToStore,
+	addNewGameToStore,
+	addNewTurnsToStore,
+	createPlayedTurn,
+	createPlayer,
+	createSkippedTurn
+} from '@/test-factories';
 import { useRoundsStore } from '@/stores/rounds';
 import { usePlayersStore } from '@/stores/players';
 import { useRules } from './useRules';

--- a/src/screens/CollectPointsScreen.vue
+++ b/src/screens/CollectPointsScreen.vue
@@ -20,6 +20,7 @@ const { t } = useGlobalI18n();
 
 const {
 	activePlayers,
+	areCollectedPointsComplete,
 	collectedPoints,
 	hasPlayerWonTheRound,
 	isComplete,
@@ -76,7 +77,10 @@ function onSavePoints(): void {
 }
 
 function onSubmit(): void {
-	emit('navigate-forward', collectedPoints.value as LeftoverPoints);
+	// Make sure all players have collected points.
+	if (!areCollectedPointsComplete(collectedPoints.value)) return;
+
+	emit('navigate-forward', collectedPoints.value);
 }
 </script>
 


### PR DESCRIPTION
The previous code asserted collectedPoints as LeftoverPoints with a bare cast, which silenced the TypeScript error but gave no compile-time safety net if the isComplete guard were ever bypassed.

- Extract areCollectedPointsComplete as a proper type predicate that narrows CollectedPoints to LeftoverPoints
- Guard the empty-object case explicitly (vacuous every() would have returned true with no entries)
- Replace the inline every() in isComplete with a call to the guard
- Use the type predicate in onSubmit to eliminate the cast entirely

Closes #62