### PR TITLE
fix(types): remove spurious roundId from ScoredTurnInput and TurnInput

### DIFF
--- a/src/types/Turn.d.ts
+++ b/src/types/Turn.d.ts
@@ -102,10 +102,10 @@ declare global {
 	type Turn = SkippedTurn | PlayedTurn;
 
 	type ScoredTurnInput =
-		| Omit<SkippedTurn, 'id' | 'playerId' | 'roundId'>
-		| Omit<PlayedTurn, 'id' | 'playerId' | 'roundId'>;
+		| Omit<SkippedTurn, 'id' | 'playerId'>
+		| Omit<PlayedTurn, 'id' | 'playerId'>;
 
 	type TurnInput =
-		| Omit<SkippedTurn, 'id' | 'playerId' | 'roundId' | 'score'>
-		| Omit<PlayedTurn, 'id' | 'playerId' | 'roundId' | 'score'>;
+		| Omit<SkippedTurn, 'id' | 'playerId' | 'score'>
+		| Omit<PlayedTurn, 'id' | 'playerId' | 'score'>;
 }


### PR DESCRIPTION
TurnBase has no roundId property, so omitting it from ScoredTurnInput and TurnInput was a no-op that misled readers into thinking roundId was being intentionally stripped.

Closes #67