### PR TITLE
fix(NumberSpinner): replace hardcoded aria-label with valueLabel prop

### DIFF
--- a/src/components/NumberSpinner.story.vue
+++ b/src/components/NumberSpinner.story.vue
@@ -6,9 +6,9 @@ import NumberSpinner from './NumberSpinner.vue';
 
 const state = reactive({
 	min: 0,
-	max: 10
+	max: 10,
+	valueLabel: 'Number of tiles drawn'
 });
-
 </script>
 
 <template>
@@ -17,6 +17,7 @@ const state = reactive({
 			<NumberSpinner
 				:min="state.min"
 				:max="state.max"
+				:value-label="state.valueLabel"
 			/>
 		</div>
 	</Story>

--- a/src/components/NumberSpinner.vue
+++ b/src/components/NumberSpinner.vue
@@ -15,6 +15,8 @@ const props = withDefaults(defineProps<{
 	 * The lowest value the spinner can have.
 	 */
 	min?: number;
+
+	valueLabel: string;
 }>(), {
 	max: Infinity,
 	min: 0
@@ -101,7 +103,7 @@ function onKeyDown(event: KeyboardEvent) {
 			:aria-valuemin="props.min"
 			:aria-valuenow="value"
 			:aria-valuetext="value.toString()"
-			aria-label="tiles drawn"
+			:aria-label="valueLabel"
 			role="spinbutton"
 			tabindex="0"
 			class="value"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -92,6 +92,7 @@
 		"bonusDoubleLabel": "Double",
 		"bonusHexagonLabel": "Hexagon",
 		"bonusScoringLabel": "Bonus scoring",
+		"numberSpinnerValueLabel": "Number of tiles drawn",
 		"tilesDrawnLabel": "Tiles drawn",
 		"tripleStone": "The played stone is a triple, all sides have the same value (+{bonus} bonus points)."
 	}

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -92,6 +92,7 @@
 		"bonusDoubleLabel": "Dubbel",
 		"bonusHexagonLabel": "Hexagoon",
 		"bonusScoringLabel": "Bonuspunten",
+		"numberSpinnerValueLabel": "Aantal getrokken stenen",
 		"tilesDrawnLabel": "Getrokken stenen",
 		"tripleStone": "De gespeelde steen is een drievoud, alle zijden hebben dezelfde waarde (+{bonus} bonuspunten)."
 	}

--- a/src/screens/TurnScreen.vue
+++ b/src/screens/TurnScreen.vue
@@ -151,6 +151,7 @@ function onToggleIsTripleStone(value: boolean) {
 				<number-spinner
 					v-model="tilesDrawn"
 					:max="3"
+					:value-label="$t('turn.numberSpinnerValueLabel')"
 				/>
 			</div>
 


### PR DESCRIPTION
The aria-label was hardcoded to "tiles drawn", making NumberSpinner inaccessible in any context where the described value is not tiles drawn, and preventing i18n. A required valueLabel prop lets callers supply the appropriate translated label.