### PR TITLE
fix(SettingsPanel): bind v-models directly to store refs

### DIFF
--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -1,36 +1,25 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import ColorSchemeSelect from '@/components/ColorSchemeSelect.vue';
 import LanguageSelect from '@/components/LanguageSelect.vue';
 
-import { useSettingsStore, type ColorScheme } from '@/stores/settings';
+import { useSettingsStore } from '@/stores/settings';
 
 /* ========================================================================== */
 
 const settingsStore = useSettingsStore();
 const { colorScheme, locale } = storeToRefs(settingsStore);
-const { setColorScheme, setLocale } = settingsStore;
-
-const selectedLocale = ref(locale.value);
-const selectedScheme = ref<ColorScheme | undefined>(colorScheme.value);
-
-/* -------------------------------------------------------------------------- */
-
-watch(selectedLocale, newValue => setLocale(newValue));
-
-watch(selectedScheme, newValue => setColorScheme(newValue));
 </script>
 
 <template>
 	<div class="section-wrapper">
 		<section>
-			<ColorSchemeSelect v-model="selectedScheme" />
+			<ColorSchemeSelect v-model="colorScheme" />
 		</section>
 
 		<section>
-			<LanguageSelect v-model="selectedLocale" />
+			<LanguageSelect v-model="locale" />
 		</section>
 	</div>
 </template>


### PR DESCRIPTION
Local refs initialised from storeToRefs snapshots do not stay in sync when the store is updated externally, e.g. during pinia-plugin-persistedstate rehydration on first load. Binding the v-models directly to the reactive refs returned by storeToRefs keeps the UI in sync in both directions without extra watches or intermediate state.

Closes #69