### PR TITLE
refactor(RoundView): replace watchEffect with explicit watch for turn key

### DIFF
--- a/src/screens/TurnScreen.vue
+++ b/src/screens/TurnScreen.vue
@@ -1,4 +1,13 @@
 <script setup lang="ts">
+/* -----------------------------------------------------------------------------
+ | Intended usage:
+ | The turn screen is meant to display a single turn. When a different turn
+ | needs to be displayed, the parent component should re-key the turn screen.
+ | This is done by passing a unique key to the `key` runtime attribute on the
+ | turn screen component in the parent template. Just updating the props will
+ | not be enough.
+ \--------------------------------------------------------------------------- */
+
 import { computed, ref, watchEffect } from 'vue';
 
 import AppScreen from '@/screens/AppScreen.vue';

--- a/src/views/RoundView.vue
+++ b/src/views/RoundView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watchEffect } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRouter } from 'vue-router';
 
@@ -50,7 +50,19 @@ const {
 	tilesPerPlayer,
 	updateTurn
 } = useRounds();
-const turnKey = ref<symbol | Id>(Symbol('turn'));
+const turnKey = ref<symbol>(Symbol('turn'));
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Whenever the current player or the historical turn player changes, indicating
+ * that a different turn is being played / shown, update the turn key to a new
+ * symbol. This forces the TurnScreen component to remount and start fresh.
+ */
+watch(
+	[currentPlayer, historicalTurnPlayer],
+	() => turnKey.value = Symbol('turn')
+);
 
 /* -------------------------------------------------------------------------- */
 
@@ -94,12 +106,6 @@ const showHistoryNavigation = computed<boolean>(() => {
 const primaryActionLabel = computed<string>(() =>
 	(historicalTurn.value === null) ? t('common.next') : t('common.update')
 );
-
-watchEffect(() => {
-	// When a historical turn is selected, use the turn's ID as the key,
-	// otherwise use a new symbol.
-	turnKey.value = historicalTurn.value?.id ?? Symbol('turn');
-});
 
 /* -------------------------------------------------------------------------- */
 
@@ -151,7 +157,6 @@ function onNavigateForwardFromStartingPlayer(playerId: Id): void {
 function onTurnPlayed(turn: TurnInput): void {
 	if (historicalTurn.value === null) {
 		saveTurn(turn);
-		turnKey.value = Symbol('turn');
 	} else if (historicalTurnPlayer.value) {
 		updateTurn(historicalTurn.value.id, turn);
 	}


### PR DESCRIPTION
TurnScreen initialises local state from props once at mount time and relies on the parent re-keying it when the displayed turn changes. The previous watchEffect drove the key from historicalTurn.value?.id, using the turn's stable ID while in history and a new Symbol otherwise. This was implicit and required a separate manual key rotation in onTurnPlayed after saveTurn.

Replace with an explicit watch on [currentPlayer, historicalTurnPlayer] that always rotates to a new Symbol, making the trigger conditions visible at a glance. The comment added to TurnScreen.vue documents the re-key contract for future contributors.