### PR TITLE
chore: remove unused CSS rules and dead template props across multiple components

### DIFF
--- a/src/components/BaseScreen.vue
+++ b/src/components/BaseScreen.vue
@@ -81,10 +81,4 @@ const props = defineProps<{
 .header {
 	grid-area: header;
 }
-
-.footer {
-	display: flex;
-	grid-area: footer;
-	justify-content: space-between;
-}
 </style>

--- a/src/components/BottomSheet.vue
+++ b/src/components/BottomSheet.vue
@@ -102,25 +102,6 @@ function onKeyDown(event: KeyboardEvent): void {
 	opacity: 1;
 }
 
-.backdrop {
-	background-color: rgba(0, 0, 0, 0.5);
-	bottom: 0;
-	height: 100%;
-	left: 0;
-	position: fixed;
-	right: 0;
-	top: 0;
-	z-index: 999; /* Ensure it appears above other content */
-}
-
-.close-button {
-	align-self: flex-end;
-	aspect-ratio: 1 / 1;
-	border-radius: 50%;
-	margin-right: get-spacing();
-	position: relative;
-}
-
 .content-container {
 	background-color: var(--color-background);
 	border-top-left-radius: get-spacing(small);

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -5,7 +5,6 @@ import { useSlot } from '@/composables/useSlot';
 /* ========================================================================== */
 
 const props = defineProps<{
-	subtitle?: string;
 	title: string;
 }>();
 
@@ -21,8 +20,6 @@ const slots = defineSlots<{
 /* -------------------------------------------------------------------------- */
 
 const { isEmpty: subtitleIsMissing } = useSlot(slots.subtitle);
-
-// const hasSubtitle = computed(() => (props.subtitle ?? '').trim() !== '');
 </script>
 
 <template>
@@ -76,7 +73,6 @@ const { isEmpty: subtitleIsMissing } = useSlot(slots.subtitle);
 .subtitle,
 .title {
 	@include truncate-text;
-	// text-align: center;
 }
 
 .subtitle {

--- a/src/components/LanguageSelect.vue
+++ b/src/components/LanguageSelect.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import SelectField, { type SelectOption } from '@/components/SelectField.vue';
-import { useGlobalI18n } from '@/i18n';
+import { useGlobalI18n, type Locale } from '@/i18n';
 
 /* ========================================================================== */
 
-const model = defineModel<string | undefined>();
+const model = defineModel<Locale | undefined>();
 
 const { t } = useGlobalI18n();
 
@@ -20,13 +20,13 @@ const options = computed<SelectOption[]>(() => [
 		id: 'en',
 		label: t('languageSelect.languageEnglish'),
 		selected: model.value === 'en',
-		value: 'en'
+		value: 'en' satisfies Locale
 	},
 	{
 		id: 'nl',
 		label: t('languageSelect.languageDutch'),
 		selected: model.value === 'nl',
-		value: 'nl'
+		value: 'nl' satisfies Locale
 	}
 ]);
 </script>

--- a/src/screens/GamePlayersScreen.vue
+++ b/src/screens/GamePlayersScreen.vue
@@ -143,8 +143,4 @@ function onDeletePlayer(id: Id) {
 	display: flex;
 	flex-direction: row;
 }
-
-.input {
-	flex-grow: 1;
-}
 </style>


### PR DESCRIPTION
Several components accumulated CSS selectors that reference classes or
elements never present in their templates, as well as dead props and
commented-out code that added noise without purpose.

- BottomSheet: remove unreferenced `.backdrop` and `.close-button` rules
- BaseScreen: remove `.footer` selector (template uses `<FooterBar>`, not
  a `.footer` class)
- HeaderBar: remove unused `subtitle` prop and delete commented-out
  computed property and CSS
- GamePlayersScreen: remove unreferenced `.input` CSS rule
- LanguageSelect: narrow `model` prop type from `string | undefined` to
  `Locale | undefined`

Closes #83