### PR TITLE
fix(i18n): derive locale validation from canonical source of truth

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -10,6 +10,9 @@ type MessageSchema = typeof en;
 
 /* ========================================================================== */
 
+export const locales: Locale[] = ['en', 'nl'];
+export const defaultLocale: Locale = 'en';
+
 export const i18n = createI18n<[MessageSchema], Locale>({
 	fallbackLocale: 'en',
 	legacy: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { createApp, watch, type Ref } from 'vue';
 import { createPinia, storeToRefs } from 'pinia';
 import piniaPluginPersistedState from 'pinia-plugin-persistedstate';
 
-import { i18n, type Locale } from '@/i18n';
+import { i18n, locales, defaultLocale, type Locale } from '@/i18n';
 
 import App from './App.vue';
 import { router } from './router';
@@ -29,10 +29,13 @@ const settings = useSettingsStore();
 const { colorScheme, locale } = storeToRefs(settings);
 
 watch(locale, selectedLocale => {
-	const validLocale: Locale = (selectedLocale === 'en' || selectedLocale === 'nl')
-		? selectedLocale
-		: 'en';
-	(i18n.global.locale as unknown as Ref<Locale>).value = validLocale;
+	const validLocale = selectedLocale === undefined
+		? false
+		: locales.includes(selectedLocale);
+	if (validLocale) return;
+
+	settings.setLocale(defaultLocale);
+	(i18n.global.locale as unknown as Ref<Locale>).value = defaultLocale;
 }, {
 	immediate: true
 });


### PR DESCRIPTION
The locale watcher in main.ts hardcoded 'en' and 'nl' directly, which could silently diverge from the Locale type in i18n/index.ts whenever a new locale was added.

- Export locales[] and defaultLocale from i18n/index.ts so both the validation check and the fallback value have a single source of truth.
- When an invalid locale is found, write defaultLocale back through the store (settings.setLocale) to clear the bad value from localStorage, and explicitly sync i18n.global.locale so the UI reflects the fallback.