### PR TITLE
refactor(PointsBottomSheet): replace close event with save and remove v-model

### DIFF
--- a/src/components/PointsBottomSheet.vue
+++ b/src/components/PointsBottomSheet.vue
@@ -2,25 +2,43 @@
 import BottomSheet from '@/components/BottomSheet.vue';
 import NumberDisplay from '@/components/NumberDisplay.vue';
 import NumberInput from '@/components/NumberInput.vue';
+import { ref, watch } from 'vue';
 
 /* ========================================================================== */
 
 const emit = defineEmits<{
 	(event: 'cancel'): void;
-	(event: 'close'): void;
+	(event: 'save', points?: number): void;
 }>();
 
-const model = defineModel<number>();
+const props = defineProps<{
+	initialPoints?: number;
 
-defineProps<{
 	/**
 	 * Controls the visibility of the BottomSheet component. If set to true,
 	 * the BottomSheet will be displayed; if false, it will be hidden.
 	 */
 	open?: boolean;
 
+	/**
+	 * The name of the player who is collecting points.
+	 */
 	playerName?: string;
 }>();
+
+/* -------------------------------------------------------------------------- */
+
+const collectedPoints = ref<number | undefined>(props.initialPoints);
+
+/* -------------------------------------------------------------------------- */
+
+// When the sheet is opened, ensure the collected points are set to the
+// initial points.
+watch(() => props.open, value => {
+	if (!value) return;
+
+	collectedPoints.value = props.initialPoints;
+});
 
 /* -------------------------------------------------------------------------- */
 
@@ -29,7 +47,7 @@ function onCancel(): void {
 }
 
 function onClose(): void {
-	emit('close');
+	emit('save', collectedPoints.value);
 }
 </script>
 
@@ -60,8 +78,8 @@ function onClose(): void {
 			</header>
 		</template>
 
-		<NumberDisplay :value="model" />
-		<NumberInput v-model="model" />
+		<NumberDisplay :value="collectedPoints" />
+		<NumberInput v-model="collectedPoints" />
 	</BottomSheet>
 </template>
 

--- a/src/screens/CollectPointsScreen.vue
+++ b/src/screens/CollectPointsScreen.vue
@@ -32,9 +32,11 @@ const {
 const isSheetOpen = ref<boolean>(false);
 const selectedPlayer = ref<Player | undefined>(undefined);
 
-const points = ref<number | undefined>(undefined);
-
 /* -------------------------------------------------------------------------- */
+
+const initialPoints = computed<number | undefined>(() =>
+	(selectedPlayer.value === undefined) ? undefined : collectedPoints.value[selectedPlayer.value.id]
+);
 
 const infoMessage = computed<string>(() => {
 	if (winningPlayerName.value === undefined) {
@@ -47,19 +49,14 @@ const infoMessage = computed<string>(() => {
 /* -------------------------------------------------------------------------- */
 
 function closeSheet(): void {
-	// Reset the state of the sheet.
 	isSheetOpen.value = false;
-
-	// Clear the selected player and points.
 	selectedPlayer.value = undefined;
-	points.value = undefined;
 }
 
 /* -------------------------------------------------------------------------- */
 
 function onCollectPoints(player: Player): void {
 	selectedPlayer.value = player;
-	points.value = collectedPoints.value[player.id];
 	isSheetOpen.value = true;
 }
 
@@ -67,12 +64,12 @@ function onCloseSheet(): void {
 	closeSheet();
 }
 
-function onSavePoints(): void {
+function onSavePoints(value?: number): void {
 	// This should never happen, but just in case.
 	if (selectedPlayer.value === undefined) return;
 
 	// Set the left over points for the selected player.
-	setCollectedPoints(selectedPlayer.value.id, points.value);
+	setCollectedPoints(selectedPlayer.value.id, value);
 
 	closeSheet();
 }
@@ -108,11 +105,11 @@ function onSubmit(): void {
 		</ol>
 
 		<PointsBottomSheet
-			v-model="points"
+			:initial-points
 			:open="isSheetOpen"
 			:player-name="selectedPlayer?.name"
 			@cancel="onCloseSheet"
-			@close="onSavePoints"
+			@save="onSavePoints"
 		/>
 
 		<template #primary-action>


### PR DESCRIPTION
PointsBottomSheet emitted close on save, which shadowed BottomSheet's close event used for dismissal. The two events carried different semantics but the same name, making the API ambiguous.

- Rename the emit from close to save and carry the points as payload
- Replace defineModel with an initialPoints prop and internal ref so the component owns its own editing state
- Update CollectPointsScreen to derive initialPoints via computed and receive the value through the save payload instead of v-model