### PR TITLE
fix(BottomSheet): reset global ref on unmount to prevent stuck scroll

### DIFF
--- a/src/components/BottomSheet.vue
+++ b/src/components/BottomSheet.vue
@@ -36,6 +36,14 @@ watch(isOpen, value => {
 
 /* -------------------------------------------------------------------------- */
 
+// When the component is unmounted, ensure the isBottomSheetOpen is set to
+// false. This is to prevent the bottom sheet from being displayed when the
+// component is unmounted. This is a workaround to prevent a UI glitch where
+// the body is still shrunk without the bottom sheet being visible.
+onUnmounted(() => isBottomSheetOpen.value = false);
+
+/* -------------------------------------------------------------------------- */
+
 function addEventListenersToDocument(): void {
 	document.addEventListener('keydown', onKeyDown);
 }


### PR DESCRIPTION
If the parent component unmounts while the sheet is open, the close handler never fires. isBottomSheetOpen stays true and App.vue keeps the no-scroll class applied indefinitely, making the app un-scrollable.