### PR TITLE
refactor: replace "stone" with "tile" across the codebase

### DIFF
--- a/.cursor/rules/domain-vocabulary.mdc
+++ b/.cursor/rules/domain-vocabulary.mdc
@@ -14,8 +14,8 @@ This app scores a game of Triominos. It does not simulate playing it.
 Game → Round(s) → Turn(s)
 ```
 
-A **game** runs until a player reaches the **points limit** (default 400).  
-A **round** consists of three phases: `player-select` → `turns` → `round-end`.  
+A **game** runs until a player reaches the **points limit** (default 400).
+A **round** consists of three phases: `player-select` → `turns` → `round-end`.
 A **turn** is one player action within the `turns` phase.
 
 ## Terms
@@ -46,17 +46,16 @@ A **turn** is one player action within the `turns` phase.
 | **turn** | One player action: play a tile, or pass |
 | **PlayedTurn** | `tilesPlayed: 1` — player placed a tile |
 | **SkippedTurn** | `tilesPlayed: 0` — player passed |
-| **opening turn** / **initial turn** | The first turn of a round; subject to triple-stone bonuses |
+| **opening turn** / **initial turn** | The first turn of a round; subject to triple-tile bonuses |
 | **tilesDrawn** | Tiles taken from the well before playing or passing (max 3 in UI) |
 
 ### Tiles / hand
 
 | Term | Meaning |
 |------|---------|
-| **tile** | Preferred term for a Triominos piece (avoid **stone** in new code) |
-| **stone** | Legacy alias for tile — still appears in some composables and i18n |
+| **tile** | Preferred term for a Triominos piece |
 | **tileValue** | Point value of the played tile |
-| **triple** / **triple stone** | Opening tile where all three sides are equal (value divisible by 3) |
+| **triple** | Opening tile where all three sides are equal (value divisible by 3) |
 | **well** | The draw pile |
 
 ### Scoring modifiers
@@ -74,7 +73,6 @@ A **turn** is one player action within the `turns` phase.
 
 ## Naming conventions
 
-- Prefer **tile** over **stone** in new code and i18n keys.
 - Use **leftoverPoints** (camelCase) for hand totals at round end.
 - Use **pointsLimit** (not `limit`, `targetScore`, or `maxPoints`).
 - Use **round winner** and **game winner** to disambiguate scope.

--- a/src/composables/useRounds.test.ts
+++ b/src/composables/useRounds.test.ts
@@ -328,7 +328,7 @@ describe('useRounds', () => {
 			useRoundsStore().updateCurrentRound({ currentPlayerId: playerAId });
 			// Bring playerA down to 1 tile so the played turn empties
 			// their hand.
-			const initialTileCount = useRules().determineStonesPerPlayer(2);
+			const initialTileCount = useRules().determineTilesPerPlayer(2);
 			useRoundsStore().updateCurrentRoundPlayerStats(playerAId, -(initialTileCount - 1), 0);
 			const { saveTurn } = useRounds();
 
@@ -469,7 +469,7 @@ describe('useRounds', () => {
 			useRounds().startNewRound();
 
 			const { playerStats } = useRoundsStore().currentRound!;
-			const initialTileCount = useRules().determineStonesPerPlayer(playerIds.length);
+			const initialTileCount = useRules().determineTilesPerPlayer(playerIds.length);
 
 			expect(playerStats).toHaveLength(playerIds.length);
 			playerStats.forEach(stat => {
@@ -494,7 +494,7 @@ describe('useRounds', () => {
 			addNewCurrentRoundToStore(playerIds);
 			const { tilesPerPlayer } = useRounds();
 
-			const initialTileCount = useRules().determineStonesPerPlayer(playerIds.length);
+			const initialTileCount = useRules().determineTilesPerPlayer(playerIds.length);
 			expect(tilesPerPlayer.value).toEqual({
 				[playerIds[0]]: initialTileCount,
 				[playerIds[1]]: initialTileCount
@@ -508,7 +508,7 @@ describe('useRounds', () => {
 
 			useRoundsStore().updateCurrentRoundPlayerStats(playerIds[0], -1, 0);
 
-			const initialTileCount = useRules().determineStonesPerPlayer(playerIds.length);
+			const initialTileCount = useRules().determineTilesPerPlayer(playerIds.length);
 			expect(tilesPerPlayer.value).toEqual({
 				[playerIds[0]]: initialTileCount - 1,
 				[playerIds[1]]: initialTileCount
@@ -562,7 +562,7 @@ describe('useRounds', () => {
 			const [existingTurn] = addNewTurnsToStore([playerAId], { tilesPlayed: 0, tilesDrawn: 0 });
 			// Bring playerA down to 1 tile so the updated played turn empties
 			// their hand.
-			const initialTileCount = useRules().determineStonesPerPlayer(2);
+			const initialTileCount = useRules().determineTilesPerPlayer(2);
 			useRoundsStore().updateCurrentRoundPlayerStats(playerAId, -(initialTileCount - 1), 0);
 			const { updateTurn } = useRounds();
 

--- a/src/composables/useRounds.ts
+++ b/src/composables/useRounds.ts
@@ -31,7 +31,7 @@ export function useRounds() {
 	const {
 		calculateTurnScore,
 		determineRoundWinnerAndPoints,
-		determineStonesPerPlayer
+		determineTilesPerPlayer
 	} = useRules();
 	const turnsStore = useTurnsStore();
 	const { t } = useGlobalI18n();
@@ -199,7 +199,7 @@ export function useRounds() {
 	function initializePlayerStats(): PlayerStats[] {
 		const stats: PlayerStats[] = [];
 		const activePlayers = playersStore.activePlayers;
-		const stoneCount = determineStonesPerPlayer(activePlayers.length);
+		const stoneCount = determineTilesPerPlayer(activePlayers.length);
 
 		for (const player of activePlayers) {
 			stats.push({

--- a/src/composables/useRounds.ts
+++ b/src/composables/useRounds.ts
@@ -199,13 +199,13 @@ export function useRounds() {
 	function initializePlayerStats(): PlayerStats[] {
 		const stats: PlayerStats[] = [];
 		const activePlayers = playersStore.activePlayers;
-		const stoneCount = determineTilesPerPlayer(activePlayers.length);
+		const tiles = determineTilesPerPlayer(activePlayers.length);
 
 		for (const player of activePlayers) {
 			stats.push({
 				id: player.id,
 				score: 0,
-				tiles: stoneCount
+				tiles
 			});
 		};
 

--- a/src/composables/useRules.test.ts
+++ b/src/composables/useRules.test.ts
@@ -313,28 +313,28 @@ describe('useRules', () => {
 
 	/* ---------------------------------------------------------------------- */
 
-	describe('determineStonesPerPlayer', () => {
+	describe('determineTilesPerPlayer', () => {
 		it('should return 9 when the number of players is 2', () => {
-			const { determineStonesPerPlayer } = useRules();
-			expect(determineStonesPerPlayer(2)).toBe(9);
+			const { determineTilesPerPlayer } = useRules();
+			expect(determineTilesPerPlayer(2)).toBe(9);
 		});
 
 		it('should return 7 when the number of players is 3 or 4', () => {
-			const { determineStonesPerPlayer } = useRules();
-			expect(determineStonesPerPlayer(3)).toBe(7);
-			expect(determineStonesPerPlayer(4)).toBe(7);
+			const { determineTilesPerPlayer } = useRules();
+			expect(determineTilesPerPlayer(3)).toBe(7);
+			expect(determineTilesPerPlayer(4)).toBe(7);
 		});
 
 		it('should return 6 when the number of players is 5 or 6', () => {
-			const { determineStonesPerPlayer } = useRules();
-			expect(determineStonesPerPlayer(5)).toBe(6);
-			expect(determineStonesPerPlayer(6)).toBe(6);
+			const { determineTilesPerPlayer } = useRules();
+			expect(determineTilesPerPlayer(5)).toBe(6);
+			expect(determineTilesPerPlayer(6)).toBe(6);
 		});
 
 		it('should return 0 when the number of players is not 2, 3, 4, 5, or 6', () => {
-			const { determineStonesPerPlayer } = useRules();
-			expect(determineStonesPerPlayer(1)).toBe(0);
-			expect(determineStonesPerPlayer(7)).toBe(0);
+			const { determineTilesPerPlayer } = useRules();
+			expect(determineTilesPerPlayer(1)).toBe(0);
+			expect(determineTilesPerPlayer(7)).toBe(0);
 		});
 	});
 });

--- a/src/composables/useRules.test.ts
+++ b/src/composables/useRules.test.ts
@@ -13,14 +13,14 @@ describe('useRules', () => {
 			expect(calculateStartingTileBonus(0)).toBe(40);
 		});
 
-		it('should return 10 for possible triple stone values', () => {
+		it('should return 10 for possible triple tile values', () => {
 			const { calculateStartingTileBonus } = useRules();
 			expect(calculateStartingTileBonus(3)).toBe(10);
 			expect(calculateStartingTileBonus(9)).toBe(10);
 			expect(calculateStartingTileBonus(15)).toBe(10);
 		});
 
-		it('should return 0 for tiles which cannot be a triple stone', () => {
+		it('should return 0 for tiles which cannot be a triple tile', () => {
 			const { calculateStartingTileBonus } = useRules();
 			expect(calculateStartingTileBonus(7)).toBe(0);
 			expect(calculateStartingTileBonus(11)).toBe(0);
@@ -161,24 +161,24 @@ describe('useRules', () => {
 
 	/* ---------------------------------------------------------------------- */
 
-	describe('canTileBeTripleStone', () => {
+	describe('canTileBeTriple', () => {
 		it('should return true for 0', () => {
-			const { canTileBeTripleStone } = useRules();
-			expect(canTileBeTripleStone(0)).toBe(true);
+			const { canTileBeTriple } = useRules();
+			expect(canTileBeTriple(0)).toBe(true);
 		});
 
 		it('should return true when the tile value is a multiple of 3', () => {
-			const { canTileBeTripleStone } = useRules();
-			expect(canTileBeTripleStone(3)).toBe(true);
-			expect(canTileBeTripleStone(9)).toBe(true);
-			expect(canTileBeTripleStone(15)).toBe(true);
+			const { canTileBeTriple } = useRules();
+			expect(canTileBeTriple(3)).toBe(true);
+			expect(canTileBeTriple(9)).toBe(true);
+			expect(canTileBeTriple(15)).toBe(true);
 		});
 
 		it('should return false when the tile value is not a multiple of 3', () => {
-			const { canTileBeTripleStone } = useRules();
-			expect(canTileBeTripleStone(7)).toBe(false);
-			expect(canTileBeTripleStone(11)).toBe(false);
-			expect(canTileBeTripleStone(2)).toBe(false);
+			const { canTileBeTriple } = useRules();
+			expect(canTileBeTriple(7)).toBe(false);
+			expect(canTileBeTriple(11)).toBe(false);
+			expect(canTileBeTriple(2)).toBe(false);
 		});
 	});
 

--- a/src/composables/useRules.test.ts
+++ b/src/composables/useRules.test.ts
@@ -7,24 +7,24 @@ import { useRules } from './useRules';
 /* ========================================================================== */
 
 describe('useRules', () => {
-	describe('calculateStartingStoneBonus', () => {
+	describe('calculateStartingTileBonus', () => {
 		it('should return 40 when the tile value is 0 (opening zero bonus)', () => {
-			const { calculateStartingStoneBonus } = useRules();
-			expect(calculateStartingStoneBonus(0)).toBe(40);
+			const { calculateStartingTileBonus } = useRules();
+			expect(calculateStartingTileBonus(0)).toBe(40);
 		});
 
 		it('should return 10 for possible triple stone values', () => {
-			const { calculateStartingStoneBonus } = useRules();
-			expect(calculateStartingStoneBonus(3)).toBe(10);
-			expect(calculateStartingStoneBonus(9)).toBe(10);
-			expect(calculateStartingStoneBonus(15)).toBe(10);
+			const { calculateStartingTileBonus } = useRules();
+			expect(calculateStartingTileBonus(3)).toBe(10);
+			expect(calculateStartingTileBonus(9)).toBe(10);
+			expect(calculateStartingTileBonus(15)).toBe(10);
 		});
 
 		it('should return 0 for tiles which cannot be a triple stone', () => {
-			const { calculateStartingStoneBonus } = useRules();
-			expect(calculateStartingStoneBonus(7)).toBe(0);
-			expect(calculateStartingStoneBonus(11)).toBe(0);
-			expect(calculateStartingStoneBonus(2)).toBe(0);
+			const { calculateStartingTileBonus } = useRules();
+			expect(calculateStartingTileBonus(7)).toBe(0);
+			expect(calculateStartingTileBonus(11)).toBe(0);
+			expect(calculateStartingTileBonus(2)).toBe(0);
 		});
 	});
 

--- a/src/composables/useRules.ts
+++ b/src/composables/useRules.ts
@@ -126,14 +126,14 @@ export function useRules() {
 	 *          tile. If the tile value is undefined, it returns 0.
 	 */
 	function calculateStartingTileBonus(tileValue: number): number {
-		if (!canTileBeTripleStone(tileValue)) return 0;
+		if (!canTileBeTriple(tileValue)) return 0;
 
 		return tileValue === 0
 			? scoreModifiers.openingZero
 			: scoreModifiers.openingTriple;
 	}
 
-	function canTileBeTripleStone(value: number): boolean {
+	function canTileBeTriple(value: number): boolean {
 		return value % 3 === 0;
 	}
 
@@ -172,7 +172,7 @@ export function useRules() {
 	return {
 		calculateStartingTileBonus,
 		calculateTurnScore,
-		canTileBeTripleStone,
+		canTileBeTriple,
 		determineRoundWinnerAndPoints,
 		determineTilesPerPlayer,
 		maximumNumberOfPlayers,

--- a/src/composables/useRules.ts
+++ b/src/composables/useRules.ts
@@ -96,7 +96,7 @@ export function useRules() {
 	}
 
 	/**
-	 * Calculates the number of starting stones per player based on the number
+	 * Calculates the number of starting tiles per player based on the number
 	 * of active players. When there are no active players, it defaults to 0.
 	 */
 	function determineTilesPerPlayer(numberOfPlayers: number): number {
@@ -122,7 +122,7 @@ export function useRules() {
 	 * @param tileValue The number of points the tile played in the turn
 	 *        is worth.
 	 *
-	 * @returns The number of bonus stones the player receives for the played
+	 * @returns The number of bonus points the player receives for the played
 	 *          tile. If the tile value is undefined, it returns 0.
 	 */
 	function calculateStartingTileBonus(tileValue: number): number {

--- a/src/composables/useRules.ts
+++ b/src/composables/useRules.ts
@@ -125,7 +125,7 @@ export function useRules() {
 	 * @returns The number of bonus stones the player receives for the played
 	 *          tile. If the tile value is undefined, it returns 0.
 	 */
-	function calculateStartingStoneBonus(tileValue: number): number {
+	function calculateStartingTileBonus(tileValue: number): number {
 		if (!canTileBeTripleStone(tileValue)) return 0;
 
 		return tileValue === 0
@@ -154,7 +154,7 @@ export function useRules() {
 		if (hasPlayedTile) {
 			// Add bonus points for the played tile if it is a triple, this can
 			// only be true for the first turn of a round.
-			if (turn.triple) score += calculateStartingStoneBonus(turn.tileValue);
+			if (turn.triple) score += calculateStartingTileBonus(turn.tileValue);
 
 			// Check for the special bonuses that can be applied to the
 			// turn score.
@@ -170,7 +170,7 @@ export function useRules() {
 	/* ---------------------------------------------------------------------- */
 
 	return {
-		calculateStartingStoneBonus,
+		calculateStartingTileBonus,
 		calculateTurnScore,
 		canTileBeTripleStone,
 		determineRoundWinnerAndPoints,

--- a/src/composables/useRules.ts
+++ b/src/composables/useRules.ts
@@ -99,7 +99,7 @@ export function useRules() {
 	 * Calculates the number of starting stones per player based on the number
 	 * of active players. When there are no active players, it defaults to 0.
 	 */
-	function determineStonesPerPlayer(numberOfPlayers: number): number {
+	function determineTilesPerPlayer(numberOfPlayers: number): number {
 		if (numberOfPlayers === 2) return 9;
 
 		if (
@@ -174,7 +174,7 @@ export function useRules() {
 		calculateTurnScore,
 		canTileBeTripleStone,
 		determineRoundWinnerAndPoints,
-		determineStonesPerPlayer,
+		determineTilesPerPlayer,
 		maximumNumberOfPlayers,
 		minimumNumberOfPlayers
 	};

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -85,7 +85,7 @@
 		"tilesLabel": "Tiles"
 	},
 	"startingPlayer": {
-		"description": "Each player gets {stones}. Select the player who will start the round.",
+		"description": "Each player gets {tiles}. Select the player who will start the round.",
 		"errorNoStartingPlayer": "You must select a player who will start the round.",
 		"title": "Round {ordinal} start"
 	},
@@ -96,6 +96,6 @@
 		"bonusScoringLabel": "Bonus scoring",
 		"numberSpinnerValueLabel": "Number of tiles drawn",
 		"tilesDrawnLabel": "Tiles drawn",
-		"tripleStone": "The played stone is a triple, all sides have the same value (+{bonus} bonus points)."
+		"tripleTile": "The played tile is a triple, all sides have the same value (+{bonus} bonus points)."
 	}
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -85,7 +85,7 @@
 		"tilesLabel": "Stenen"
 	},
 	"startingPlayer": {
-		"description": "Elke speler krijgt {stones}. Kies de speler die de ronde zal beginnen.",
+		"description": "Elke speler krijgt {tiles}. Kies de speler die de ronde zal beginnen.",
 		"errorNoStartingPlayer": "Je moet een speler selecteren die de ronde zal beginnen.",
 		"title": "Start ronde {ordinal}"
 	},
@@ -96,6 +96,6 @@
 		"bonusScoringLabel": "Bonuspunten",
 		"numberSpinnerValueLabel": "Aantal getrokken stenen",
 		"tilesDrawnLabel": "Getrokken stenen",
-		"tripleStone": "De gespeelde steen is een drievoud, alle zijden hebben dezelfde waarde (+{bonus} bonuspunten)."
+		"tripleTile": "De gespeelde steen is een drievoud, alle zijden hebben dezelfde waarde (+{bonus} bonuspunten)."
 	}
 }

--- a/src/screens/StartingPlayerScreen.vue
+++ b/src/screens/StartingPlayerScreen.vue
@@ -29,7 +29,7 @@ const { activePlayers } = storeToRefs(playerStore);
 
 const { determineTilesPerPlayer } = useRules();
 
-const stonesPerPlayer = computed<number>(
+const tilesPerPlayer = computed<number>(
 	() => determineTilesPerPlayer(activePlayers.value.length)
 );
 
@@ -64,8 +64,8 @@ function onNavigateForward(): void {
 				keypath="startingPlayer.description"
 				tag="div"
 			>
-				<template #stones>
-					<strong>{{ $t('common.tile', stonesPerPlayer) }}</strong>
+				<template #tiles>
+					<strong>{{ $t('common.tile', tilesPerPlayer) }}</strong>
 				</template>
 			</i18n-t>
 		</MessageBox>

--- a/src/screens/StartingPlayerScreen.vue
+++ b/src/screens/StartingPlayerScreen.vue
@@ -27,10 +27,10 @@ const playerStore = usePlayersStore();
 
 const { activePlayers } = storeToRefs(playerStore);
 
-const { determineStonesPerPlayer } = useRules();
+const { determineTilesPerPlayer } = useRules();
 
 const stonesPerPlayer = computed<number>(
-	() => determineStonesPerPlayer(activePlayers.value.length)
+	() => determineTilesPerPlayer(activePlayers.value.length)
 );
 
 const selectedId = ref<Id | undefined>(undefined);

--- a/src/screens/TurnScreen.vue
+++ b/src/screens/TurnScreen.vue
@@ -43,7 +43,7 @@ const props = withDefaults(defineProps<{
 
 /* -------------------------------------------------------------------------- */
 
-const { calculateStartingStoneBonus, canTileBeTripleStone } = useRules();
+const { calculateStartingTileBonus, canTileBeTripleStone } = useRules();
 
 /* -------------------------------------------------------------------------- */
 
@@ -60,7 +60,7 @@ const tileValue = ref<number | undefined>(props.turn?.tileValue);
 /* -------------------------------------------------------------------------- */
 
 const openingTurnBonus = computed<number>(() =>
-	(tileValue.value === undefined) ? 0 : calculateStartingStoneBonus(tileValue.value)
+	(tileValue.value === undefined) ? 0 : calculateStartingTileBonus(tileValue.value)
 );
 
 const isTripleStoneEnabled = computed<boolean>(() =>

--- a/src/screens/TurnScreen.vue
+++ b/src/screens/TurnScreen.vue
@@ -43,7 +43,7 @@ const props = withDefaults(defineProps<{
 
 /* -------------------------------------------------------------------------- */
 
-const { calculateStartingTileBonus, canTileBeTripleStone } = useRules();
+const { calculateStartingTileBonus, canTileBeTriple } = useRules();
 
 /* -------------------------------------------------------------------------- */
 
@@ -64,7 +64,7 @@ const openingTurnBonus = computed<number>(() =>
 );
 
 const isTripleStoneEnabled = computed<boolean>(() =>
-	(tileValue.value === undefined) ? false : canTileBeTripleStone(tileValue.value)
+	(tileValue.value === undefined) ? false : canTileBeTriple(tileValue.value)
 );
 
 /* -------------------------------------------------------------------------- */

--- a/src/screens/TurnScreen.vue
+++ b/src/screens/TurnScreen.vue
@@ -50,7 +50,7 @@ const { calculateStartingTileBonus, canTileBeTriple } = useRules();
 // These refs are initialized once from props.turn at mount time. The parent is
 // responsible for re-keying this component whenever the turn changes, so no
 // watchers are needed here.
-const isTripleStone = ref<boolean>(
+const isTripleTile = ref<boolean>(
 	props.turn?.tilesPlayed === 1 ? props.turn.triple : false
 );
 const selectedBonusShape = ref<BonusShape | undefined>(getInitialBonusShape());
@@ -63,18 +63,18 @@ const openingTurnBonus = computed<number>(() =>
 	(tileValue.value === undefined) ? 0 : calculateStartingTileBonus(tileValue.value)
 );
 
-const isTripleStoneEnabled = computed<boolean>(() =>
+const isTripleTileEnabled = computed<boolean>(() =>
 	(tileValue.value === undefined) ? false : canTileBeTriple(tileValue.value)
 );
 
 /* -------------------------------------------------------------------------- */
 
 watchEffect(() => {
-	if (isTripleStoneEnabled.value) return;
+	if (isTripleTileEnabled.value) return;
 
-	// When the played value cannot be a triple, the isTripleStone flag should
+	// When the played value cannot be a triple, the isTripleTile flag should
 	// be reset to false.
-	isTripleStone.value = false;
+	isTripleTile.value = false;
 });
 
 /* -------------------------------------------------------------------------- */
@@ -101,7 +101,7 @@ function createTurnInput(): TurnInput {
 			tilesDrawn: props.isInitialTurn ? 0 : tilesDrawn.value,
 			tilesPlayed: 1,
 			tileValue: tileValue.value,
-			triple: props.isInitialTurn && isTripleStone.value
+			triple: props.isInitialTurn && isTripleTile.value
 		};
 }
 
@@ -128,8 +128,8 @@ function onNavigateForward() {
 	emit('turn-played', createTurnInput());
 }
 
-function onToggleIsTripleStone(value: boolean) {
-	isTripleStone.value = value;
+function onToggleIsTripleTile(value: boolean) {
+	isTripleTile.value = value;
 }
 </script>
 
@@ -143,12 +143,12 @@ function onToggleIsTripleStone(value: boolean) {
 
 		<template v-if="isInitialTurn">
 			<ToggleButton
-				v-if="isTripleStoneEnabled"
+				v-if="isTripleTileEnabled"
 				:allow-wrap="true"
-				:is-selected="isTripleStone"
-				@toggle="onToggleIsTripleStone"
+				:is-selected="isTripleTile"
+				@toggle="onToggleIsTripleTile"
 			>
-				{{ $t('turn.tripleStone', { bonus: openingTurnBonus }) }}
+				{{ $t('turn.tripleTile', { bonus: openingTurnBonus }) }}
 			</ToggleButton>
 		</template>
 		<template v-else>

--- a/src/stores/rounds.test.ts
+++ b/src/stores/rounds.test.ts
@@ -189,7 +189,7 @@ describe('Rounds Store', () => {
 		});
 
 		it('should update the current round player stats with the provided update', () => {
-			const initialTiles = useRules().determineStonesPerPlayer(2);
+			const initialTiles = useRules().determineTilesPerPlayer(2);
 			const playerA = generateId();
 			const playerB = generateId();
 			const round = addNewCurrentRoundToStore([playerA, playerB]);
@@ -384,7 +384,7 @@ describe('Rounds Store', () => {
 		});
 
 		it('should return the number of tiles for the player in the current round', () => {
-			const initialTiles = useRules().determineStonesPerPlayer(2);
+			const initialTiles = useRules().determineTilesPerPlayer(2);
 			const playerId = generateId();
 			// A valid game needs at least two players.
 			addNewCurrentRoundToStore([playerId, generateId()]);

--- a/src/test-factories/round.ts
+++ b/src/test-factories/round.ts
@@ -9,7 +9,7 @@ import { assertActivePinia } from './assertActivePinia';
 /* ========================================================================== */
 
 function createCurrentRound(playerIds: Id[], phase: RoundPhase = 'turns', winnerId?: Id): CurrentRound {
-	const tileCount = useRules().determineStonesPerPlayer(playerIds.length);
+	const tileCount = useRules().determineTilesPerPlayer(playerIds.length);
 
 	return {
 		id: generateId(),


### PR DESCRIPTION
The codebase used "stone" and "tile" interchangeably as names for
Triominos pieces. This inconsistency made domain language ambiguous and
harder to navigate. This PR establishes "tile" as the single preferred
term.

## Changes

- Rename `determineStonesPerPlayer` → `determineTilesPerPlayer`
- Rename `calculateStartingStoneBonus` → `calculateStartingTileBonus`
- Rename `canTileBeTripleStone` → `canTileBeTriple`
- Update all call sites, tests, and local variables
- Update i18n keys `tripleStone` → `tripleTile` and interpolation
  parameter `{stones}` → `{tiles}` in both `en.json` and `nl.json`
- Update `domain-vocabulary.mdc` to remove "stone" as a legacy alias
  and reflect the settled naming

No behaviour changes.