### PR TITLE
refactor(usePlayerManager): return Feedback from addNewPlayer

### DIFF
--- a/src/composables/usePlayerManager.test.ts
+++ b/src/composables/usePlayerManager.test.ts
@@ -1,8 +1,10 @@
 import { createPinia, setActivePinia } from 'pinia';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { usePlayerManager } from './usePlayerManager';
 import { generateId } from '@/utilities/id';
 import { useRules } from './useRules';
+import type { SuccessFeedback } from '@/types/Feedback';
+import { assertSuccessfulFeedback } from '@/test-factories/assertSuccessfulFeedback';
 
 /* ========================================================================== */
 
@@ -14,17 +16,21 @@ function addPlayers(playerManager: ReturnType<typeof usePlayerManager>, count: n
 
 /* -------------------------------------------------------------------------- */
 
+vi.mock('@/i18n');
+
+/* -------------------------------------------------------------------------- */
+
 beforeEach(() => setActivePinia(createPinia()));
 
 /* -------------------------------------------------------------------------- */
 
 describe('usePlayerManager', () => {
 	describe('addNewPlayer', () => {
-		it('should return undefined if the name is not a valid name', () => {
+		it('should return a feedback object with a false success property if the name is not a valid name', () => {
 			const playerManager = usePlayerManager();
 
-			expect(playerManager.addNewPlayer('')).toBeUndefined();
-			expect(playerManager.addNewPlayer('   ')).toBeUndefined();
+			expect(playerManager.addNewPlayer('')).toEqual({ success: false, message: 'error.invalidName' });
+			expect(playerManager.addNewPlayer('   ')).toEqual({ success: false, message: 'error.invalidName' });
 
 			expect(playerManager.players.value).toHaveLength(0);
 		});
@@ -33,9 +39,13 @@ describe('usePlayerManager', () => {
 			const playerManager = usePlayerManager();
 
 			const name = 'John Doe';
-			const id = playerManager.addNewPlayer(name);
+			const result = playerManager.addNewPlayer(name);
 
-			expect(id).toBeDefined();
+			expect(result.success).toBe(true);
+
+			const id = (result as SuccessFeedback<Id>).payload;
+			expect(id).toBeTypeOf('string');
+
 			expect(playerManager.players.value).toHaveLength(1);
 			expect(playerManager.players.value[0]).toEqual({
 				active: true,
@@ -50,7 +60,7 @@ describe('usePlayerManager', () => {
 	describe('deletePlayer', () => {
 		it('should do nothing if the player with the specified ID is not found', () => {
 			const playerManager = usePlayerManager();
-			const id = playerManager.addNewPlayer('John Doe');
+			const id = assertSuccessfulFeedback(playerManager.addNewPlayer('John Doe'));
 
 			playerManager.deletePlayer(generateId());
 
@@ -64,10 +74,10 @@ describe('usePlayerManager', () => {
 
 		it('should only delete the player with the specified ID', () => {
 			const playerManager = usePlayerManager();
-			const idJohn = playerManager.addNewPlayer('John Doe');
-			const idJane = playerManager.addNewPlayer('Jane Doe');
+			const idJohn = assertSuccessfulFeedback(playerManager.addNewPlayer('John Doe'));
+			const idJane = assertSuccessfulFeedback(playerManager.addNewPlayer('Jane Doe'));
 
-			playerManager.deletePlayer(idJohn!);
+			playerManager.deletePlayer(idJohn);
 
 			expect(playerManager.players.value).toHaveLength(1);
 			expect(playerManager.players.value[0].id).toBe(idJane);
@@ -256,9 +266,9 @@ describe('usePlayerManager', () => {
 		it('should return the list of players', () => {
 			const playerManager = usePlayerManager();
 
-			const idJohn = playerManager.addNewPlayer('John Doe');
-			const idJane = playerManager.addNewPlayer('Jane Doe');
-			const idJim = playerManager.addNewPlayer('Jim Doe');
+			const idJohn = assertSuccessfulFeedback(playerManager.addNewPlayer('John Doe'));
+			const idJane = assertSuccessfulFeedback(playerManager.addNewPlayer('Jane Doe'));
+			const idJim = assertSuccessfulFeedback(playerManager.addNewPlayer('Jim Doe'));
 
 			expect(playerManager.players.value).toHaveLength(3);
 			expect(playerManager.players.value[0]).toEqual({

--- a/src/composables/usePlayerManager.ts
+++ b/src/composables/usePlayerManager.ts
@@ -1,7 +1,11 @@
 import { computed, readonly } from 'vue';
 import { storeToRefs } from 'pinia';
 
+import { useGlobalI18n } from '@/i18n';
+
 import { usePlayersStore } from '@/stores/players';
+
+import type { Feedback } from '@/types/Feedback';
 
 import { generateId } from '@/utilities/id';
 import { isNilOrEmptyString } from '@/utilities/string';
@@ -12,6 +16,7 @@ import { useRules } from './useRules';
 
 export function usePlayerManager() {
 	const playerStore = usePlayersStore();
+	const { t } = useGlobalI18n();
 
 	/* ---------------------------------------------------------------------- */
 
@@ -51,8 +56,8 @@ export function usePlayerManager() {
 	 * @returns The ID of the newly added player, or undefined if the name
 	 *          is not a valid name.
 	 */
-	function addNewPlayer(name: string): Id | undefined {
-		if (!isValidName(name)) return;
+	function addNewPlayer(name: string): Feedback<Id> {
+		if (!isValidName(name)) return { success: false, message: t('error.invalidName') };
 
 		const id: Id = generateId();
 
@@ -62,7 +67,7 @@ export function usePlayerManager() {
 			name
 		});
 
-		return id;
+		return { success: true, payload: id };
 	}
 
 	/**

--- a/src/composables/usePlayerManager.ts
+++ b/src/composables/usePlayerManager.ts
@@ -53,8 +53,8 @@ export function usePlayerManager() {
 	 *
 	 * @param name The name of the player to add.
 	 *
-	 * @returns The ID of the newly added player, or undefined if the name
-	 *          is not a valid name.
+	 * @returns A feedback object indicating success or failure. In case of
+	 *          success, the payload is the ID of the newly added player.
 	 */
 	function addNewPlayer(name: string): Feedback<Id> {
 		if (!isValidName(name)) return { success: false, message: t('error.invalidName') };

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -28,6 +28,7 @@
 	},
 	"error": {
 		"hasCurrentRound": "Invalid action, there is already a current round",
+		"invalidName": "Invalid name, the name must be at least 1 character long",
 		"noActiveGame": "Invalid action, there is no active game",
 		"noCurrentPlayer": "Invalid action, there is no current player",
 		"noCurrentRound": "Invalid action, there is no current round",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -28,6 +28,7 @@
 	},
 	"error": {
 		"hasCurrentRound": "Ongeldige actie, er is al een huidige ronde",
+		"invalidName": "Ongeldige naam, de naam moet minimaal 1 karakter lang zijn",
 		"noActiveGame": "Ongeldige actie, er is geen actieve game",
 		"noCurrentPlayer": "Ongeldige actie, er is geen huidige speler",
 		"noCurrentRound": "Ongeldige actie, er is geen huidige ronde",

--- a/src/screens/GamePlayersScreen.vue
+++ b/src/screens/GamePlayersScreen.vue
@@ -47,7 +47,9 @@ watch(name, () => validationError.value = undefined);
 function onAddPlayer(event: Event) {
 	event.preventDefault();
 
-	if (addNewPlayer(name.value) === undefined) return;
+	const result = addNewPlayer(name.value);
+
+	if (!result.success) return;
 
 	name.value = '';
 }

--- a/src/screens/GamePlayersScreen.vue
+++ b/src/screens/GamePlayersScreen.vue
@@ -38,9 +38,13 @@ const {
 } = usePlayerManager();
 
 const name = ref('');
+const nameValidationErrorMessage = ref<string | undefined>(undefined);
 const validationError = ref<string | undefined>(undefined);
 
-watch(name, () => validationError.value = undefined);
+watch(name, () => {
+	nameValidationErrorMessage.value = undefined;
+	validationError.value = undefined;
+});
 
 /* -------------------------------------------------------------------------- */
 
@@ -49,7 +53,10 @@ function onAddPlayer(event: Event) {
 
 	const result = addNewPlayer(name.value);
 
-	if (!result.success) return;
+	if (!result.success) {
+		nameValidationErrorMessage.value = result.message;
+		return;
+	}
 
 	name.value = '';
 }
@@ -104,6 +111,13 @@ function onDeletePlayer(id: Id) {
 					</button>
 				</template>
 			</TextInput>
+
+			<MessageBox
+				v-if="nameValidationErrorMessage"
+				type="warning"
+			>
+				{{ nameValidationErrorMessage }}
+			</MessageBox>
 		</form>
 
 		<section>
@@ -144,6 +158,6 @@ function onDeletePlayer(id: Id) {
 <style lang="scss" scoped>
 .form {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 }
 </style>

--- a/src/test-factories/assertSuccessfulFeedback.ts
+++ b/src/test-factories/assertSuccessfulFeedback.ts
@@ -1,0 +1,12 @@
+import type { Feedback } from '@/types/Feedback';
+
+/* ========================================================================== */
+
+export function assertSuccessfulFeedback<T>(feedback: Feedback<T>): T {
+	if (!feedback.success) {
+		throw new Error(`Expected successful feedback, got error: ${feedback.message}`);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	return (feedback as any).payload;
+}

--- a/src/types/Feedback.ts
+++ b/src/types/Feedback.ts
@@ -10,13 +10,13 @@ type ErrorFeedback = {
 	success: false;
 };
 
-type SuccessFeedback<T = void> = {
+/* ========================================================================== */
+
+export type SuccessFeedback<T = void> = {
 	/**
 	 * Indicates whether the operation was successful or not.
 	 */
 	success: true;
 } & (T extends void ? object : { payload: T });
-
-/* ========================================================================== */
 
 export type Feedback<T = void> = ErrorFeedback | SuccessFeedback<T>;


### PR DESCRIPTION
Changes `addNewPlayer` from returning `Id | undefined` to returning
`Feedback<Id>`, aligning it with every other mutating operation in the
composable layer.

Updates `GamePlayersScreen` to consume the new return type:

- Checks `result.success` before clearing the name input
- Displays `result.message` in a `<MessageBox>` when the call fails
- Keeps name-input errors (`nameValidationErrorMessage`) separate from
  continue-button errors (`validationError`), so each has its own
  display slot and lifecycle

## Why

`addNewPlayer` was the only mutating composable operation that did not
return a `Feedback` object. Callers had to null-check the return value
and supply their own error strings, breaking the convention established
throughout the codebase and leaving `GamePlayersScreen` unable to show
the composable's validation message.

Closes #72