### PR TITLE
fix(RoundView): check Feedback from all composable calls

### DIFF
--- a/src/screens/CollectPointsScreen.vue
+++ b/src/screens/CollectPointsScreen.vue
@@ -19,6 +19,13 @@ const emit = defineEmits<{
 	(event: 'navigate-forward', leftoverPoints: PlayerScoreMap): void;
 }>();
 
+defineProps<{
+	/**
+	 * Optional property to pass an error message to the screen.
+	 */
+	errorMessage?: string;
+}>();
+
 /* -------------------------------------------------------------------------- */
 
 const { t } = useGlobalI18n();
@@ -107,6 +114,13 @@ function onSubmit(): void {
 				</li>
 			</template>
 		</ol>
+
+		<MessageBox
+			v-if="errorMessage"
+			type="warning"
+		>
+			{{ errorMessage }}
+		</MessageBox>
 
 		<PointsBottomSheet
 			:initial-points

--- a/src/screens/TurnScreen.vue
+++ b/src/screens/TurnScreen.vue
@@ -11,6 +11,7 @@
 import { computed, ref, watchEffect } from 'vue';
 
 import BaseScreen from '@/components/BaseScreen.vue';
+import MessageBox from '@/components/MessageBox.vue';
 import NumberDisplay from '@/components/NumberDisplay.vue';
 import NumberInput from '@/components/NumberInput.vue';
 import NumberSpinner from '@/components/NumberSpinner.vue';
@@ -33,6 +34,7 @@ const emit = defineEmits<{
 }>();
 
 const props = withDefaults(defineProps<{
+	errorMessage: string | undefined;
 	isInitialTurn?: boolean;
 	primaryActionLabel: string;
 	subtitle: string;
@@ -140,6 +142,13 @@ function onToggleIsTripleTile(value: boolean) {
 		:title
 		:subtitle
 	>
+		<MessageBox
+			v-if="errorMessage"
+			type="warning"
+		>
+			{{ errorMessage }}
+		</MessageBox>
+
 		<NumberDisplay :value="tileValue" />
 		<NumberInput v-model="tileValue" />
 

--- a/src/views/RoundView.vue
+++ b/src/views/RoundView.vue
@@ -53,6 +53,8 @@ const {
 } = useRounds();
 const turnKey = ref<symbol>(Symbol('turn'));
 
+const feedbackMessage = ref<string | undefined>(undefined);
+
 /* -------------------------------------------------------------------------- */
 
 /**
@@ -135,14 +137,26 @@ function onNavigateForwardInHistory(): void {
 }
 
 function onNavigateForwardFromCollectPoints(leftoverPoints: Record<Id, number>): void {
-	finishCurrentRound(leftoverPoints);
+	feedbackMessage.value = undefined;
+
+	const result = finishCurrentRound(leftoverPoints);
+	if (!result.success) {
+		feedbackMessage.value = result.message;
+		return;
+	}
+
 	// Check if the game is over and when it is, go to the game over screen.
 	if (hasReachedPointsLimit.value) {
 		// The game is finished, go to the game over screen.
 		router.replace({ name: routeName.gameResult });
-	} else {
-		// The game is not yet finished, start a new round.
-		startNewRound();
+		return;
+	}
+
+	// The game is not yet finished, start a new round.
+	const newRoundResult = startNewRound();
+	if (!newRoundResult.success) {
+		feedbackMessage.value = newRoundResult.message;
+		return;
 	}
 }
 
@@ -196,6 +210,7 @@ function onTurnPlayed(turn: TurnInput): void {
 
 	<CollectPointsScreen
 		v-else-if="currentPhase === 'round-end'"
+		:error-message="feedbackMessage"
 		@navigate-forward="onNavigateForwardFromCollectPoints"
 	/>
 </template>

--- a/src/views/RoundView.vue
+++ b/src/views/RoundView.vue
@@ -53,7 +53,7 @@ const {
 } = useRounds();
 const turnKey = ref<symbol>(Symbol('turn'));
 
-const feedbackMessage = ref<string | undefined>(undefined);
+const errorMessage = ref<string | undefined>(undefined);
 
 /* -------------------------------------------------------------------------- */
 
@@ -113,9 +113,11 @@ const primaryActionLabel = computed<string>(() =>
 /* -------------------------------------------------------------------------- */
 
 onMounted(() => {
-	if (!hasCurrentRound.value) startNewRound();
-});
+	if (hasCurrentRound.value) return;
 
+	const result = startNewRound();
+	if (!result.success) console.error('Unexpected: startNewRound failed on mount', result.message);
+});
 /* -------------------------------------------------------------------------- */
 
 /**
@@ -137,11 +139,11 @@ function onNavigateForwardInHistory(): void {
 }
 
 function onNavigateForwardFromCollectPoints(leftoverPoints: Record<Id, number>): void {
-	feedbackMessage.value = undefined;
+	errorMessage.value = undefined;
 
 	const result = finishCurrentRound(leftoverPoints);
 	if (!result.success) {
-		feedbackMessage.value = result.message;
+		errorMessage.value = result.message;
 		return;
 	}
 
@@ -154,10 +156,9 @@ function onNavigateForwardFromCollectPoints(leftoverPoints: Record<Id, number>):
 
 	// The game is not yet finished, start a new round.
 	const newRoundResult = startNewRound();
-	if (!newRoundResult.success) {
-		feedbackMessage.value = newRoundResult.message;
-		return;
-	}
+	// startNewRound cannot fail at this point: we just completed the
+	// current round, and the game is still active.
+	if (!newRoundResult.success) console.error('Unexpected: startNewRound failed', newRoundResult.message);
 }
 
 /**
@@ -166,14 +167,21 @@ function onNavigateForwardFromCollectPoints(leftoverPoints: Record<Id, number>):
  * @param playerId The ID of the player to set as the starting player.
  */
 function onNavigateForwardFromStartingPlayer(playerId: Id): void {
-	setStartingPlayer(playerId);
+	const result = setStartingPlayer(playerId);
+	// This should never happen and if it does, it is not something the user can
+	// do something to recover from this.
+	if (!result.success) console.error('Unexpected: setStartingPlayer failed', result.message);
 }
 
 function onTurnPlayed(turn: TurnInput): void {
+	errorMessage.value = undefined;
+
 	if (historicalTurn.value === null) {
-		saveTurn(turn);
+		const result = saveTurn(turn);
+		if (!result.success) errorMessage.value = result.message;
 	} else if (historicalTurnPlayer.value) {
-		updateTurn(historicalTurn.value.id, turn);
+		const result = updateTurn(historicalTurn.value.id, turn);
+		if (!result.success) errorMessage.value = result.message;
 	}
 }
 </script>
@@ -188,6 +196,7 @@ function onTurnPlayed(turn: TurnInput): void {
 	<TurnScreen
 		v-else-if="currentPhase === 'turns'"
 		:key="turnKey"
+		:error-message="errorMessage"
 		:is-initial-turn="isInitialTurn"
 		:primary-action-label="primaryActionLabel"
 		:subtitle
@@ -210,7 +219,7 @@ function onTurnPlayed(turn: TurnInput): void {
 
 	<CollectPointsScreen
 		v-else-if="currentPhase === 'round-end'"
-		:error-message="feedbackMessage"
+		:error-message="errorMessage"
 		@navigate-forward="onNavigateForwardFromCollectPoints"
 	/>
 </template>


### PR DESCRIPTION
`RoundView` was calling five mutating composable operations without ever inspecting their `Feedback` return value. Failures were silently discarded and execution continued regardless, leading to cascading state corruption — most critically, navigating to a new round or the game result screen even when `finishCurrentRound` had failed.

Two commits address this:

- **Show errors from handling point collection** — `finishCurrentRound` and the subsequent `startNewRound` in `onNavigateForwardFromCollectPoints` now check `result.success`. On failure, `errorMessage` is set and navigation is blocked. `CollectPointsScreen` receives and displays the message.
- **Show errors in TurnScreen** — `saveTurn` and `updateTurn` in `onTurnPlayed` now check `result.success` and surface failures via `errorMessage` to `TurnScreen`. `setStartingPlayer` and the `startNewRound` calls in `onMounted` and post-`finishCurrentRound` are also checked; failures there are treated as unexpected/unrecoverable and logged via `console.error` since the user has no recovery path.

## Why

The `Feedback` convention exists on every mutating composable operation. `RoundView` was the only consumer that never honoured it, making it the single place in the app where an operation could silently fail and leave the store in an inconsistent state.

Closes #60