### PR TITLE
refactor(useRounds): surface game-over signal from finishCurrentRound

### DIFF
--- a/src/composables/usePlayerManager.test.ts
+++ b/src/composables/usePlayerManager.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { usePlayerManager } from './usePlayerManager';
 import { generateId } from '@/utilities/id';
 import { useRules } from './useRules';
-import type { SuccessFeedback } from '@/types/Feedback';
 import { assertSuccessfulFeedback } from '@/test-factories/assertSuccessfulFeedback';
 
 /* ========================================================================== */
@@ -43,7 +42,7 @@ describe('usePlayerManager', () => {
 
 			expect(result.success).toBe(true);
 
-			const id = (result as SuccessFeedback<Id>).payload;
+			const id = result.success && result.id;
 			expect(id).toBeTypeOf('string');
 
 			expect(playerManager.players.value).toHaveLength(1);
@@ -60,7 +59,7 @@ describe('usePlayerManager', () => {
 	describe('deletePlayer', () => {
 		it('should do nothing if the player with the specified ID is not found', () => {
 			const playerManager = usePlayerManager();
-			const id = assertSuccessfulFeedback(playerManager.addNewPlayer('John Doe'));
+			const id = assertSuccessfulFeedback(playerManager.addNewPlayer('John Doe'), 'id');
 
 			playerManager.deletePlayer(generateId());
 
@@ -74,8 +73,8 @@ describe('usePlayerManager', () => {
 
 		it('should only delete the player with the specified ID', () => {
 			const playerManager = usePlayerManager();
-			const idJohn = assertSuccessfulFeedback(playerManager.addNewPlayer('John Doe'));
-			const idJane = assertSuccessfulFeedback(playerManager.addNewPlayer('Jane Doe'));
+			const idJohn = assertSuccessfulFeedback(playerManager.addNewPlayer('John Doe'), 'id');
+			const idJane = assertSuccessfulFeedback(playerManager.addNewPlayer('Jane Doe'), 'id');
 
 			playerManager.deletePlayer(idJohn);
 
@@ -266,9 +265,9 @@ describe('usePlayerManager', () => {
 		it('should return the list of players', () => {
 			const playerManager = usePlayerManager();
 
-			const idJohn = assertSuccessfulFeedback(playerManager.addNewPlayer('John Doe'));
-			const idJane = assertSuccessfulFeedback(playerManager.addNewPlayer('Jane Doe'));
-			const idJim = assertSuccessfulFeedback(playerManager.addNewPlayer('Jim Doe'));
+			const idJohn = assertSuccessfulFeedback(playerManager.addNewPlayer('John Doe'), 'id');
+			const idJane = assertSuccessfulFeedback(playerManager.addNewPlayer('Jane Doe'), 'id');
+			const idJim = assertSuccessfulFeedback(playerManager.addNewPlayer('Jim Doe'), 'id');
 
 			expect(playerManager.players.value).toHaveLength(3);
 			expect(playerManager.players.value[0]).toEqual({

--- a/src/composables/usePlayerManager.ts
+++ b/src/composables/usePlayerManager.ts
@@ -56,7 +56,7 @@ export function usePlayerManager() {
 	 * @returns A feedback object indicating success or failure. In case of
 	 *          success, the payload is the ID of the newly added player.
 	 */
-	function addNewPlayer(name: string): Feedback<Id> {
+	function addNewPlayer(name: string): Feedback<{ id: Id }> {
 		if (!isValidName(name)) return { success: false, message: t('error.invalidName') };
 
 		const id: Id = generateId();
@@ -67,7 +67,7 @@ export function usePlayerManager() {
 			name
 		});
 
-		return { success: true, payload: id };
+		return { id, success: true };
 	}
 
 	/**

--- a/src/composables/useRounds.test.ts
+++ b/src/composables/useRounds.test.ts
@@ -152,7 +152,7 @@ describe('useRounds', () => {
 
 			const result = finishCurrentRound({ [playerAId]: 5, [playerBId]: 10 });
 
-			expect(result).toEqual({ success: true });
+			expect(result.success).toBe(true);
 			expect(useRoundsStore().completedRounds[0].winnerId).toBe(playerAId);
 		});
 
@@ -164,7 +164,7 @@ describe('useRounds', () => {
 
 			const result = finishCurrentRound({ [playerBId]: 10 });
 
-			expect(result).toEqual({ success: true });
+			expect(result.success).toBe(true);
 			expect(useRoundsStore().completedRounds[0].winnerId).toBe(playerAId);
 		});
 
@@ -183,7 +183,7 @@ describe('useRounds', () => {
 
 			const result = rounds.finishCurrentRound(scores);
 
-			expect(result).toEqual({ success: true });
+			expect(result.success).toBe(true);
 			expect(roundsStore.currentRound).toBeUndefined();
 			expect(roundsStore.completedRounds).toHaveLength(1);
 			expect(roundsStore.completedRounds[0]).toMatchObject({ winnerId: playerId, scores: endScores });
@@ -199,6 +199,28 @@ describe('useRounds', () => {
 			finishCurrentRound({ [playerBId]: 10 });
 
 			expect(useTurnsStore().turns).toHaveLength(0);
+		});
+
+		it('should return success and the game over flag when the game is over', () => {
+			const playerAId = addNewPlayersToStore(1)[0].id;
+			addNewGameToStore(100);
+			addNewCurrentRoundToStore([playerAId]);
+			useRoundsStore().updateCurrentRound({ winnerId: playerAId });
+			const { finishCurrentRound } = useRounds();
+
+			const result = finishCurrentRound({ [playerAId]: 100 });
+			expect(result).toEqual({ success: true, gameOver: true });
+		});
+
+		it('should return success and the game over flag false when the game is not over', () => {
+			const playerAId = addNewPlayersToStore(1)[0].id;
+			addNewGameToStore(100);
+			addNewCurrentRoundToStore([playerAId]);
+			useRoundsStore().updateCurrentRound({ winnerId: playerAId });
+			const { finishCurrentRound } = useRounds();
+
+			const result = finishCurrentRound({ [playerAId]: 50 });
+			expect(result).toEqual({ success: true, gameOver: false });
 		});
 	});
 
@@ -578,7 +600,7 @@ describe('useRounds', () => {
 			expect(useRoundsStore().currentRound?.winnerId).toBe(playerAId);
 		});
 
-		it('should mark the round as blocked when  updated turn makes all players have consecutively skipped', () => {
+		it('should mark the round as blocked when updated turn makes all players have consecutively skipped', () => {
 			const players = addNewPlayersToStore(2);
 			const [playerAId, playerBId] = players.map(p => p.id);
 			addNewCurrentRoundToStore([playerAId, playerBId]);

--- a/src/composables/useRounds.ts
+++ b/src/composables/useRounds.ts
@@ -174,8 +174,10 @@ export function useRounds() {
 		}, {});
 
 		return {
-			payload: { isBlocked, scores, winnerId: pointsForWinner.winnerId },
-			success: true
+			isBlocked,
+			scores,
+			success: true,
+			winnerId: pointsForWinner.winnerId
 		} satisfies ComputeFinalScoresResult;
 	}
 
@@ -304,7 +306,7 @@ export function useRounds() {
 		}
 
 		return {
-			payload: { playerId: originalTurn.playerId },
+			playerId: originalTurn.playerId,
 			success: true
 		};
 	}
@@ -327,14 +329,14 @@ export function useRounds() {
 
 		// When the round is blocked, this is the first opportunity to set the
 		// winner of the round.
-		if (result.payload.isBlocked) {
+		if (result.isBlocked) {
 			roundsStore.updateCurrentRound({
-				winnerId: result.payload.winnerId
+				winnerId: result.winnerId
 			});
 		}
 
 		try {
-			roundsStore.completeCurrentRound(result.payload.scores);
+			roundsStore.completeCurrentRound(result.scores);
 		} catch (error) {
 			// completeCurrentRound can throw an error when there is no current
 			// round but the method already ensures there is a current at the
@@ -437,7 +439,7 @@ export function useRounds() {
 		const replaceResult = replaceTurn(turnId, turn);
 		if (!replaceResult.success) return replaceResult;
 
-		handleRoundEnd(replaceResult.payload.playerId);
+		handleRoundEnd(replaceResult.playerId);
 
 		return { success: true };
 	}

--- a/src/composables/useRounds.ts
+++ b/src/composables/useRounds.ts
@@ -25,6 +25,7 @@ import type { Feedback } from '@/types/Feedback';
 import { generateId } from '@/utilities/id';
 
 import { useRules } from './useRules';
+import { useGameScores } from './useGameScores';
 
 /* ========================================================================== */
 
@@ -33,6 +34,10 @@ type ComputeFinalScoresResult = Feedback<{
 	scores: PlayerScoreMap;
 	winnerId: Id;
 }>;
+
+type FinishCurrentRoundPayload = {
+	gameOver: boolean;
+};
 
 /* ========================================================================== */
 
@@ -47,6 +52,9 @@ export function useRounds() {
 	const gameStore = useGameStore();
 	const playersStore = usePlayersStore();
 	const roundsStore = useRoundsStore();
+	const {
+		hasReachedPointsLimit
+	} = useGameScores();
 	const {
 		calculateTurnScore,
 		determineRoundWinnerAndPoints,
@@ -320,10 +328,11 @@ export function useRounds() {
 	 * @param scores A record of scores for each player in the round, where the
 	 *        keys are player IDs and the values are their scores.
 	 *
-	 * @returns True if the round was successfully finished, false if there is
-	 *          no current round to finish.
+	 * @returns In case the round was successfully finished, the returned
+	 *          feedback object will contain a game over flag indicating whether
+	 *          the game has reached the points limit.
 	 */
-	function finishCurrentRound(leftOverPoints: PlayerScoreMap): Feedback {
+	function finishCurrentRound(leftOverPoints: PlayerScoreMap): Feedback<FinishCurrentRoundPayload> {
 		const result = computeFinalScores(leftOverPoints);
 		if (!result.success) return result;
 
@@ -358,7 +367,10 @@ export function useRounds() {
 		// moment ago. Once it is finished, its turns are no longer editable.
 		turnsStore.deleteTurns();
 
-		return { success: true };
+		return {
+			gameOver: hasReachedPointsLimit.value,
+			success: true
+		};
 	}
 
 	function saveTurn(turn: TurnInput): Feedback {

--- a/src/test-factories/assertSuccessfulFeedback.ts
+++ b/src/test-factories/assertSuccessfulFeedback.ts
@@ -1,12 +1,21 @@
-import type { Feedback } from '@/types/Feedback';
+import type { Feedback, SuccessFeedback } from '@/types/Feedback';
 
 /* ========================================================================== */
 
-export function assertSuccessfulFeedback<T>(feedback: Feedback<T>): T {
+export function assertSuccessfulFeedback<T, K extends keyof SuccessFeedback<T>>(
+	feedback: Feedback<T>, property: K
+): SuccessFeedback<T>[K];
+export function assertSuccessfulFeedback<T>(feedback: Feedback<T>): SuccessFeedback<T>;
+export function assertSuccessfulFeedback<T, K extends keyof SuccessFeedback<T>>(
+	feedback: Feedback<T>, property?: K
+): SuccessFeedback<T>[K] | SuccessFeedback<T> {
 	if (!feedback.success) {
 		throw new Error(`Expected successful feedback, got error: ${feedback.message}`);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	return (feedback as any).payload;
+	if (property === undefined) {
+		return feedback as SuccessFeedback<T>;
+	}
+
+	return (feedback as SuccessFeedback<T>)[property];
 }

--- a/src/types/Feedback.ts
+++ b/src/types/Feedback.ts
@@ -17,6 +17,6 @@ export type SuccessFeedback<T = void> = {
 	 * Indicates whether the operation was successful or not.
 	 */
 	success: true;
-} & (T extends void ? object : { payload: T });
+} & (T extends void ? object : T);
 
 export type Feedback<T = void> = ErrorFeedback | SuccessFeedback<T>;

--- a/src/views/RoundView.vue
+++ b/src/views/RoundView.vue
@@ -28,7 +28,7 @@ const router = useRouter();
 const { t } = useGlobalI18n();
 const roundsStore = useRoundsStore();
 
-const { hasReachedPointsLimit, totalScore } = useGameScores();
+const { totalScore } = useGameScores();
 const {
 	canGoBack,
 	canGoForward,
@@ -148,7 +148,7 @@ function onNavigateForwardFromCollectPoints(leftoverPoints: Record<Id, number>):
 	}
 
 	// Check if the game is over and when it is, go to the game over screen.
-	if (hasReachedPointsLimit.value) {
+	if (result.gameOver) {
 		// The game is finished, go to the game over screen.
 		router.replace({ name: routeName.gameResult });
 		return;


### PR DESCRIPTION
**What this PR does**

`RoundView` was directly consulting `hasReachedPointsLimit` to decide whether to navigate to the game-over screen after finishing a round. That decision is domain logic that belongs inside `useRounds`, not in the view. This PR moves it there by returning a `gameOver` flag from `finishCurrentRound`. As a prerequisite, the intermediate `payload` wrapper on `Feedback<T>` is removed — it made accessing success data unnecessarily verbose and is not needed.

**Key changes**

- `Feedback<T>` no longer nests success data under a `payload` property; properties now sit directly on the return object, reducing access verbosity across all callers (`useRounds`, `usePlayerManager`, test factories)
- `finishCurrentRound` now returns `{ gameOver: boolean }` as part of its success feedback, derived from `hasReachedPointsLimit` inside `useRounds`
- `RoundView` reads `result.gameOver` instead of importing `useGameScores` for game-end detection; the view no longer owns that decision

**Testing notes**

`useRounds.test.ts` covers `gameOver: true` and `gameOver: false` return values directly without mounting the view. `RoundView.test.ts` verifies navigation is triggered when the flag is set. `assertSuccessfulFeedback` in the test factories was updated to match the flattened `Feedback` shape.

**Closes**

Closes #118