### PR TITLE
refactor(router): extract navigation policy into a testable seam

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,6 +6,8 @@ import { useRoundsStore } from '@/stores/rounds';
 
 import { routeName } from '@/router/routerName';
 
+import { evaluateRoute } from '@/utilities/navigationPolicy';
+
 /* ========================================================================== */
 
 const router = createRouter({
@@ -52,35 +54,11 @@ router.beforeEach(to => {
 	const playersStore = usePlayersStore();
 	const roundsStore = useRoundsStore();
 
-	// Check first if the route requires active players, if these are not
-	// present redirect to the home view.
-	if (to.meta.requireActivePlayers && !playersStore.hasActivePlayers) {
-		return { name: routeName.home };
-	}
-
-	// We know now that there are active players, so we can check if the route
-	// requires an active game. When no active game is present, redirect to the
-	// game limit view.
-	if (to.meta.requireActiveGame && !gameStore.hasActiveGame) {
-		return { name: routeName.gameLimit };
-	}
-
-	// We know there is a game, so we can check if the route requires a finished
-	// game. When there is a current round, the game is not yet finished. In
-	// this case, redirect to the round view.
-	if (to.meta.requireFinishedGame && roundsStore.hasCurrentRound) {
-		return { name: routeName.round };
-	}
-
-	// When arriving at home, forward to the deepest applicable view.
-	if (to.name === routeName.home) {
-		if (playersStore.hasActivePlayers && gameStore.hasActiveGame) {
-			if (roundsStore.hasCurrentRound) {
-				return { name: routeName.round };
-			}
-			return { name: routeName.gameResult };
-		}
-	}
+	return evaluateRoute(to, {
+		hasActivePlayers: playersStore.hasActivePlayers,
+		hasActiveGame: gameStore.hasActiveGame,
+		hasCurrentRound: roundsStore.hasCurrentRound
+	});
 });
 
 /* ========================================================================== */

--- a/src/utilities/navigationPolicy.test.ts
+++ b/src/utilities/navigationPolicy.test.ts
@@ -1,0 +1,135 @@
+import type { RouteLocationNormalized, RouteMeta } from 'vue-router';
+import { describe, expect, it } from 'vitest';
+
+import { routeName } from '@/router/routerName';
+
+import { evaluateRoute } from './navigationPolicy';
+
+/* ========================================================================== */
+
+function createRoute(name: string, meta: RouteMeta = {}): RouteLocationNormalized {
+	return {
+		fullPath: name,
+		hash: '',
+		matched: [],
+		meta,
+		name,
+		params: {},
+		path: name,
+		query: {},
+		redirectedFrom: undefined
+	};
+}
+
+/* -------------------------------------------------------------------------- */
+
+describe('navigationPolicy', () => {
+	describe('evaluateRoute', () => {
+		describe('requireActivePlayers', () => {
+			it('should redirect to home when there are no active players', () => {
+				const route = createRoute(routeName.round, { requireActivePlayers: true });
+				const state = { hasActivePlayers: false, hasActiveGame: false, hasCurrentRound: false };
+
+				expect(evaluateRoute(route, state)).toEqual({ name: routeName.home });
+			});
+
+			it('should allow the route when there are active players', () => {
+				const route = createRoute(routeName.round, { requireActivePlayers: true });
+				const state = { hasActivePlayers: true, hasActiveGame: false, hasCurrentRound: false };
+
+				expect(evaluateRoute(route, state)).toBeUndefined();
+			});
+		});
+
+		/* -------------------------------------------------------------- */
+
+		describe('requireActiveGame', () => {
+			it('should redirect to the game limit when there is no active game', () => {
+				const route = createRoute(routeName.round, { requireActiveGame: true });
+				const state = { hasActivePlayers: true, hasActiveGame: false, hasCurrentRound: false };
+
+				expect(evaluateRoute(route, state)).toEqual({ name: routeName.gameLimit });
+			});
+
+			it('should allow the route when there is an active game', () => {
+				const route = createRoute(routeName.round, { requireActiveGame: true });
+				const state = { hasActivePlayers: true, hasActiveGame: true, hasCurrentRound: false };
+
+				expect(evaluateRoute(route, state)).toBeUndefined();
+			});
+		});
+
+		/* -------------------------------------------------------------- */
+
+		describe('requireFinishedGame', () => {
+			it('should redirect to the round when the game is not finished', () => {
+				const route = createRoute(routeName.gameResult, { requireFinishedGame: true });
+				const state = { hasActivePlayers: true, hasActiveGame: true, hasCurrentRound: true };
+
+				expect(evaluateRoute(route, state)).toEqual({ name: routeName.round });
+			});
+
+			it('should allow the route when the game is finished', () => {
+				const route = createRoute(routeName.gameResult, { requireFinishedGame: true });
+				const state = { hasActivePlayers: true, hasActiveGame: true, hasCurrentRound: false };
+
+				expect(evaluateRoute(route, state)).toBeUndefined();
+			});
+		});
+
+		/* -------------------------------------------------------------- */
+
+		describe('home forwarding', () => {
+			it('should forward to the round when a round is in progress', () => {
+				const route = createRoute(routeName.home);
+				const state = { hasActivePlayers: true, hasActiveGame: true, hasCurrentRound: true };
+
+				expect(evaluateRoute(route, state)).toEqual({ name: routeName.round });
+			});
+
+			it('should forward to the game result when the game has no current round', () => {
+				const route = createRoute(routeName.home);
+				const state = { hasActivePlayers: true, hasActiveGame: true, hasCurrentRound: false };
+
+				expect(evaluateRoute(route, state)).toEqual({ name: routeName.gameResult });
+			});
+
+			it('should stay on home when there is no active game', () => {
+				const route = createRoute(routeName.home);
+				const state = { hasActivePlayers: true, hasActiveGame: false, hasCurrentRound: false };
+
+				expect(evaluateRoute(route, state)).toBeUndefined();
+			});
+
+			it('should stay on home when there are no active players', () => {
+				const route = createRoute(routeName.home);
+				const state = { hasActivePlayers: false, hasActiveGame: true, hasCurrentRound: true };
+
+				expect(evaluateRoute(route, state)).toBeUndefined();
+			});
+		});
+
+		/* -------------------------------------------------------------- */
+
+		describe('precedence', () => {
+			it('should redirect to the game limit when players are present but no game exists', () => {
+				const route = createRoute(routeName.round, {
+					requireActiveGame: true,
+					requireActivePlayers: true
+				});
+				const state = { hasActivePlayers: true, hasActiveGame: false, hasCurrentRound: false };
+
+				expect(evaluateRoute(route, state)).toEqual({ name: routeName.gameLimit });
+			});
+		});
+
+		/* -------------------------------------------------------------- */
+
+		it('should allow a route without requirements', () => {
+			const route = createRoute(routeName.gameLimit);
+			const state = { hasActivePlayers: false, hasActiveGame: false, hasCurrentRound: false };
+
+			expect(evaluateRoute(route, state)).toBeUndefined();
+		});
+	});
+});

--- a/src/utilities/navigationPolicy.ts
+++ b/src/utilities/navigationPolicy.ts
@@ -1,0 +1,49 @@
+import type { RouteLocationNormalized, RouteLocationRaw } from 'vue-router';
+
+import { routeName } from '@/router/routerName';
+
+/* ========================================================================== */
+
+type NavigationState = {
+	hasActivePlayers: boolean;
+	hasActiveGame: boolean;
+	hasCurrentRound: boolean;
+};
+
+/* ========================================================================== */
+
+export function evaluateRoute(to: RouteLocationNormalized, state: NavigationState): RouteLocationRaw | undefined {
+	// Check first if the route requires active players, if these are not
+	// present redirect to the home view.
+	if (to.meta.requireActivePlayers && !state.hasActivePlayers) {
+		return { name: routeName.home };
+	}
+
+	// We know now that there are active players, so we can check if the
+	// route requires an active game. When no active game is present,
+	// redirect to the game limit view.
+	if (to.meta.requireActiveGame && !state.hasActiveGame) {
+		return { name: routeName.gameLimit };
+	}
+
+	// We know there is a game, so we can check if the route requires a
+	// finished game. When there is a current round, the game is not yet
+	// finished. In this case, redirect to the round view.
+	if (to.meta.requireFinishedGame && state.hasCurrentRound) {
+		return { name: routeName.round };
+	}
+
+	// When arriving at home, forward to the deepest applicable view.
+	if (to.name === routeName.home) {
+		if (state.hasActivePlayers && state.hasActiveGame) {
+			if (state.hasCurrentRound) {
+				return { name: routeName.round };
+			}
+
+			return { name: routeName.gameResult };
+		}
+	}
+
+	// No special handling is needed for this route.
+	return undefined;
+}


### PR DESCRIPTION
The redirect rules lived entirely inside router.beforeEach, the only untested business logic in the codebase. They could not be exercised without mounting the full router, so there was no seam for tests.

Moving the decision logic into a pure evaluateRoute utility lets the guard call into it with plain state, so every redirect branch is now covered without Pinia or a router mount (resolves #120).