### PR TITLE
refactor(feedback): collapse store-composable error seam (#133)

### DIFF
--- a/src/composables/useRounds.ts
+++ b/src/composables/useRounds.ts
@@ -23,6 +23,7 @@ import {
 import type { Feedback } from '@/types/Feedback';
 
 import { generateId } from '@/utilities/id';
+import { toFeedback } from '@/utilities/toFeedback';
 
 import {
 	calculateTurnScore,
@@ -255,21 +256,14 @@ export function useRounds() {
 		// Store the turn in the turns store.
 		turnsStore.addTurn(turn);
 
-		try {
+		return toFeedback(() => {
 			// Update the stats for the current player in the current round.
 			roundsStore.updateCurrentRoundPlayerStats(
 				playerId,
 				turn.tilesDrawn - turn.tilesPlayed,
 				turn.score
 			);
-		} catch (error) {
-			return {
-				message: (error as Error).message,
-				success: false
-			};
-		}
-
-		return { success: true };
+		});
 	}
 
 	function replaceTurn(turnId: Id, turn: TurnInput): Feedback<{ playerId: Id }> {
@@ -304,19 +298,11 @@ export function useRounds() {
 			(originalTurn.tilesDrawn - originalTurn.tilesPlayed);
 		const scoreDelta = score - originalTurn.score;
 
-		try {
+		return toFeedback<{ playerId: Id }>(() => {
 			roundsStore.updateCurrentRoundPlayerStats(originalTurn.playerId, tileDelta, scoreDelta);
-		} catch (error) {
-			return {
-				message: (error as PlayerIdNotFoundError).message,
-				success: false
-			};
-		}
 
-		return {
-			playerId: originalTurn.playerId,
-			success: true
-		};
+			return { playerId: originalTurn.playerId };
+		});
 	}
 
 	/* ---------------------------------------------------------------------- */
@@ -344,24 +330,19 @@ export function useRounds() {
 			});
 		}
 
-		try {
-			roundsStore.completeCurrentRound(result.scores);
-		} catch (error) {
-			// completeCurrentRound can throw an error when there is no current
-			// round but the method already ensures there is a current at the
-			// beginning. That leaves just the PlayerIdNotFoundError to handle.
-			if (error instanceof PlayerIdNotFoundError) {
-				return {
-					message: t('error.noWinner'),
-					success: false
-				};
-			}
+		const completeResult = toFeedback(
+			() => roundsStore.completeCurrentRound(result.scores),
+			error =>
+				// completeCurrentRound can throw an error when there is no
+				// current round but the method already ensures there is a
+				// current at the beginning. That leaves just the
+				// PlayerIdNotFoundError to handle.
+				(error instanceof PlayerIdNotFoundError)
+					? t('error.noWinner')
+					: error.message
+		);
 
-			return {
-				message: (error as Error).message,
-				success: false
-			};
-		}
+		if (!completeResult.success) return completeResult;
 
 		// Clear the turns for the round which was the current round up to a
 		// moment ago. Once it is finished, its turns are no longer editable.

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,3 +1,4 @@
+export { AppError } from './AppError';
 export { CurrentRoundAlreadyExistsError } from './CurrentRoundAlreadyExists';
 export { NoCurrentRoundExistsError } from './NoCurrentRoundExists';
 export { PlayerIdNotFoundError } from './PlayerIdNotFound';

--- a/src/utilities/toFeedback.test.ts
+++ b/src/utilities/toFeedback.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { toFeedback } from './toFeedback';
+import { AppError } from '@/errors';
+
+/* ========================================================================== */
+
+describe('toFeedback', () => {
+	it('should return a successful feedback when there is no error', () => {
+		const result = toFeedback(() => undefined);
+		expect(result).toEqual({ success: true });
+	});
+
+	it('should include the result in the successful feedback when it is not void', () => {
+		const result = toFeedback(() => ({ value: 'test' }));
+		expect(result).toEqual({ success: true, value: 'test' });
+	});
+
+	it('should rethrow non-AppError errors', () => {
+		expect(() => toFeedback(() => {
+			throw new Error('test');
+		})).toThrow('test');
+	});
+
+	it('should return an error feedback when an AppError is thrown', () => {
+		const result = toFeedback(() => {
+			throw new AppError('test');
+		});
+		expect(result).toEqual({ success: false, message: 'test' });
+	});
+
+	it('should return an error feedback when an AppError is thrown with a custom message', () => {
+		const result = toFeedback(
+			() => {
+				throw new AppError('test');
+			},
+			() => 'custom message'
+		);
+		expect(result).toEqual({ success: false, message: 'custom message' });
+	});
+});

--- a/src/utilities/toFeedback.ts
+++ b/src/utilities/toFeedback.ts
@@ -1,0 +1,25 @@
+import { AppError } from '@/errors';
+
+import type { Feedback, SuccessFeedback } from '@/types/Feedback';
+
+/* ========================================================================== */
+
+export function toFeedback<T extends Record<string, unknown> | void = void>(
+	fn: () => T, mapError?: (error: AppError) => string
+): Feedback<T> {
+	try {
+		const result = fn();
+
+		return { success: true, ...(result ?? {}) } as SuccessFeedback<T>;
+	} catch (error) {
+		if (error instanceof AppError) {
+			const message = mapError?.(error) ?? error.message;
+
+			return { message, success: false };
+		}
+
+		// A non-AppError error means a programming error, not user feedback.
+		// Let it surface.
+		throw error;
+	}
+}


### PR DESCRIPTION
Composables wrapped each throwing store call in a near-identical try/catch that re-mapped AppErrors to Feedback, forcing callers to know both the throw and the Feedback contracts at every site.

Introduce a single toFeedback adapter that owns the AppError-to-Feedback conversion, rethrows genuine programming errors, and lets callers learn Feedback only. Rewrites insertTurn, replaceTurn, and finishCurrentRound onto the adapter and covers it with dedicated unit tests.

Closes #133 